### PR TITLE
Target net35 as well as netstandard1.0

### DIFF
--- a/DiffPlex/DiffPlex.csproj
+++ b/DiffPlex/DiffPlex.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFrameworks>net35;netstandard1.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Version>1.4.1</Version>
     <Authors>Matthew Manela</Authors>

--- a/DiffPlex/Log.cs
+++ b/DiffPlex/Log.cs
@@ -7,7 +7,7 @@ namespace DiffPlex
         [Conditional("LOG")]
         public static void WriteLine(string format, params object[] args)
         {
-            Debug.WriteLine(format, args);
+            Debug.WriteLine(string.Format(format, args));
         }
 
         [Conditional("LOG")]


### PR DESCRIPTION
I tested out 1.4.1 and because I'm using old-style `.csproj`/`packages.config` files and targeting `net45`, it included a whole bunch of `System.*` packages in my project.

This probably doesn't happen for users of the newer VS2017 `.csproj` file format, but it's straightforward to also include `net35` binaries in the same NuGet package. `msbuild` should do that automatically with this change.

Here is an example of the diff brought about after updating to 1.4.1.

```diff
 <packages>
-  <package id="DiffPlex" version="1.2.1" targetFramework="net45" />
+  <package id="DiffPlex" version="1.4.1" targetFramework="net45" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net45" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net45" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net45" />
 </packages>
```

I believe that if you can release this as 1.4.2 then it would instead be:

```diff
 <packages>
-  <package id="DiffPlex" version="1.4.1" targetFramework="net45" />
+  <package id="DiffPlex" version="1.4.2" targetFramework="net45" />
 </packages>
```