### PR TITLE
Fix xUnit assert warnings

### DIFF
--- a/Facts.DiffPlex/DifferFacts.cs
+++ b/Facts.DiffPlex/DifferFacts.cs
@@ -586,8 +586,8 @@ namespace Facts.DiffPlex
 
                 differ.TestBuildModificationData(a, b);
 
-                Assert.Equal(0, a.Modifications.Length);
-                Assert.Equal(0, b.Modifications.Length);
+                Assert.Empty(a.Modifications);
+                Assert.Empty(b.Modifications);
             }
 
             [Fact]

--- a/Facts.DiffPlex/SideBySideDiffBuilderFacts.cs
+++ b/Facts.DiffPlex/SideBySideDiffBuilderFacts.cs
@@ -316,19 +316,19 @@ namespace Facts.DiffPlex
                 var bidiff = builder.BuildDiffModel(textOld, textNew);
 
                 Assert.NotNull(bidiff);
-                Assert.Equal(1, bidiff.OldText.Lines.Count);
-                Assert.Equal(1, bidiff.NewText.Lines.Count);
-                Assert.Equal(bidiff.NewText.Lines[0].SubPieces[0].Type, ChangeType.Unchanged);
-                Assert.Equal(bidiff.NewText.Lines[0].SubPieces[1].Type, ChangeType.Inserted);
-                Assert.Equal(bidiff.NewText.Lines[0].SubPieces[2].Type, ChangeType.Unchanged);
-                Assert.Equal(bidiff.NewText.Lines[0].SubPieces[3].Type, ChangeType.Inserted);
-                Assert.Equal(bidiff.NewText.Lines[0].SubPieces[4].Type, ChangeType.Unchanged);
+                Assert.Single(bidiff.OldText.Lines);
+                Assert.Single(bidiff.NewText.Lines);
+                Assert.Equal(ChangeType.Unchanged, bidiff.NewText.Lines[0].SubPieces[0].Type);
+                Assert.Equal(ChangeType.Inserted, bidiff.NewText.Lines[0].SubPieces[1].Type);
+                Assert.Equal(ChangeType.Unchanged, bidiff.NewText.Lines[0].SubPieces[2].Type);
+                Assert.Equal(ChangeType.Inserted, bidiff.NewText.Lines[0].SubPieces[3].Type);
+                Assert.Equal(ChangeType.Unchanged, bidiff.NewText.Lines[0].SubPieces[4].Type);
 
-                Assert.Equal(bidiff.OldText.Lines[0].SubPieces[0].Type, ChangeType.Unchanged);
-                Assert.Equal(bidiff.OldText.Lines[0].SubPieces[1].Type, ChangeType.Imaginary);
-                Assert.Equal(bidiff.OldText.Lines[0].SubPieces[2].Type, ChangeType.Unchanged);
-                Assert.Equal(bidiff.OldText.Lines[0].SubPieces[3].Type, ChangeType.Imaginary);
-                Assert.Equal(bidiff.OldText.Lines[0].SubPieces[4].Type, ChangeType.Unchanged);
+                Assert.Equal(ChangeType.Unchanged, bidiff.OldText.Lines[0].SubPieces[0].Type);
+                Assert.Equal(ChangeType.Imaginary, bidiff.OldText.Lines[0].SubPieces[1].Type);
+                Assert.Equal(ChangeType.Unchanged, bidiff.OldText.Lines[0].SubPieces[2].Type);
+                Assert.Equal(ChangeType.Imaginary, bidiff.OldText.Lines[0].SubPieces[3].Type);
+                Assert.Equal(ChangeType.Unchanged, bidiff.OldText.Lines[0].SubPieces[4].Type);
             }
         }
     }


### PR DESCRIPTION
xUnit throws some warnings for some `Assert` statements that don't follow the convention. This PR fixes those warnings.