### PR TITLE
Add net40 to multitargeting

### DIFF
--- a/DiffPlex/DiffPlex.csproj
+++ b/DiffPlex/DiffPlex.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;netstandard1.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Version>1.4.1</Version>
     <Authors>Matthew Manela</Authors>

--- a/Facts.DiffPlex/Facts.DiffPlex.csproj
+++ b/Facts.DiffPlex/Facts.DiffPlex.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds `net40` target framework for `DiffPlex`, but for the test project, I had to target `net452` (XUnit requirement) and upgrade XUnit too.

Fixes #28 . The `net40` should satisfy #28's requirement as `net452` is a drop-in replacement for `net40`.