### PR TITLE
Generate AppVeyor artifacts upon building

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,3 +14,6 @@ test:
     - Facts.DiffPlex.dll
 test_script:
   - dotnet test .\Facts.DiffPlex\Facts.DiffPlex.csproj --configuration Release --no-build
+artifacts:
+  - path: DiffPlex/bin/%CONFIGURATION%/*/DiffPlex.dll
+  - path: DiffPlex/bin/%CONFIGURATION%/*.nupkg


### PR DESCRIPTION
This addition to the CI build will generate the NuGet packages as artifacts. This should ease the process to get a new version on NuGet.

Please rebase, not merge.