### PR TITLE
fixing "Differ" so that it doesn't generate so crazy amount of tokens…

### DIFF
--- a/DiffPlex/Differ.cs
+++ b/DiffPlex/Differ.cs
@@ -124,17 +124,51 @@ namespace DiffPlex
         {
             var list = new List<string>();
             int begin = 0;
+            bool processingDelim = false;
+            int delimBegin = 0;
             for (int i = 0; i < str.Length; i++)
             {
                 if (Array.IndexOf(delims, str[i]) != -1)
                 {
-                    list.Add(str.Substring(begin, (i - begin)));
-                    list.Add(str.Substring(i, 1));
+                    if (i >= str.Length - 1)
+                    {
+                        if (processingDelim)
+                        {
+                            list.Add(str.Substring(delimBegin, (i + 1 - delimBegin)));
+                        }
+                        else
+                        {
+                            list.Add(str.Substring(begin, 1));
+                        }
+                    }
+                    else
+                    {
+                        if (!processingDelim)
+                        {
+                            list.Add(str.Substring(begin, (i - begin)));
+                            processingDelim = true;
+                            delimBegin = i;
+                        }
+                    }
+                    
                     begin = i + 1;
                 }
-                else if (i >= str.Length - 1)
+                else
                 {
-                    list.Add(str.Substring(begin, (i + 1 - begin)));
+                    if (processingDelim)
+                    {
+                        if (i - delimBegin > 0)
+                        {
+                            list.Add(str.Substring(delimBegin, (i - delimBegin)));
+                        }
+
+                        processingDelim = false;
+                    }
+
+                    if (i >= str.Length - 1)
+                    {
+                        list.Add(str.Substring(begin, (i + 1 - begin)));
+                    }
                 }
             }
 

--- a/Facts.DiffPlex/DifferFacts.cs
+++ b/Facts.DiffPlex/DifferFacts.cs
@@ -556,18 +556,44 @@ namespace Facts.DiffPlex
                 var res = differ.CreateWordDiffs(string.Format("z{0}a{0}{0}", ' '), string.Format("z{0}v{0}{0}", ';'), false, new[] { ' ', ';' });
 
                 Assert.NotNull(res);
-                Assert.Equal(2, res.DiffBlocks.Count);
+                Assert.Equal(1, res.DiffBlocks.Count);
 
                 Assert.Equal(1, res.DiffBlocks[0].DeleteStartA);
                 Assert.Equal(3, res.DiffBlocks[0].DeleteCountA);
                 Assert.Equal(1, res.DiffBlocks[0].InsertStartB);
                 Assert.Equal(3, res.DiffBlocks[0].InsertCountB);
+            }
 
+            [Fact]
+            public void Will_return_correct_diff_for_multiple_chained_separators()
+            {
+                var differ = new TestableDiffer();
 
-                Assert.Equal(5, res.DiffBlocks[1].DeleteStartA);
-                Assert.Equal(1, res.DiffBlocks[1].DeleteCountA);
-                Assert.Equal(5, res.DiffBlocks[1].InsertStartB);
-                Assert.Equal(1, res.DiffBlocks[1].InsertCountB);
+                var res = differ.CreateWordDiffs("z a       ", "z a", false, new[] { ' ' });
+
+                Assert.NotNull(res);
+                Assert.Equal(1, res.DiffBlocks.Count);
+
+                Assert.Equal(3, res.DiffBlocks[0].DeleteStartA);
+                Assert.Equal(1, res.DiffBlocks[0].DeleteCountA);
+                Assert.Equal(3, res.DiffBlocks[0].InsertStartB);
+                Assert.Equal(0, res.DiffBlocks[0].InsertCountB);
+            }
+
+            [Fact]
+            public void Will_return_correct_diff_for_multiple_chained_separators_ending_with_char()
+            {
+                var differ = new TestableDiffer();
+
+                var res = differ.CreateWordDiffs("z a       b", "z ab", false, new[] { ' ' });
+
+                Assert.NotNull(res);
+                Assert.Equal(1, res.DiffBlocks.Count);
+
+                Assert.Equal(2, res.DiffBlocks[0].DeleteStartA);
+                Assert.Equal(3, res.DiffBlocks[0].DeleteCountA);
+                Assert.Equal(2, res.DiffBlocks[0].InsertStartB);
+                Assert.Equal(1, res.DiffBlocks[0].InsertCountB);
             }
         }
 


### PR DESCRIPTION
The problem can be demonstrated by diffing two outputs of following powershell script: 
```
(Get-Host).UI.RawUI.BufferSize = New-Object Management.Automation.Host.Size (4096, 4096)
Get-Process
```

This produce text output with many empty spaces and diffplex returns 8000 tokens for each line of code (for each space it returns 2 tokens)

The fix is just optimizing `SmartSplit` method to be smarter and aggregate spacing characters