### PR TITLE
#47: Implement chunker that preserves line endings

### DIFF
--- a/DiffPlex/Chunkers/CharacterChunker.cs
+++ b/DiffPlex/Chunkers/CharacterChunker.cs
@@ -1,0 +1,12 @@
+﻿namespace DiffPlex.Chunkers
+{
+    public class CharacterChunker:IChunker
+    {
+        public string[] Chunk(string text)
+        {
+            var s = new string[text.Length];
+            for (int i = 0; i < text.Length; i++) s[i] = text[i].ToString();
+            return s;
+        }
+    }
+}

--- a/DiffPlex/Chunkers/CustomFunctionChunker.cs
+++ b/DiffPlex/Chunkers/CustomFunctionChunker.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace DiffPlex.Chunkers
+{
+    public class CustomFunctionChunker: IChunker
+    {
+        private readonly Func<string, string[]> customChunkerFunc;
+
+        public CustomFunctionChunker(Func<string, string[]> customChunkerFunc)
+        {
+            if(customChunkerFunc == null) throw new ArgumentNullException(nameof(customChunkerFunc));
+            this.customChunkerFunc = customChunkerFunc;
+        }
+
+        public string[] Chunk(string text)
+        {
+            return customChunkerFunc(text);
+        }
+    }
+}

--- a/DiffPlex/Chunkers/DelimiterChunker.cs
+++ b/DiffPlex/Chunkers/DelimiterChunker.cs
@@ -9,7 +9,11 @@ namespace DiffPlex.Chunkers
 
         public DelimiterChunker(char[] delimiters)
         {
-            if (delimiters == null) throw new ArgumentNullException(nameof(delimiters));
+            if (delimiters is null || delimiters.Length == 0)
+            {
+                throw new ArgumentException($"{nameof(delimiters)} cannot be null or empty.", nameof(delimiters));
+            }
+
             this.delimiters = delimiters;
         }
 

--- a/DiffPlex/Chunkers/DelimiterChunker.cs
+++ b/DiffPlex/Chunkers/DelimiterChunker.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DiffPlex.Chunkers
+{
+    public class DelimiterChunker:IChunker
+    {
+        private readonly char[] delimiters;
+
+        public DelimiterChunker(char[] delimiters)
+        {
+            if (delimiters == null) throw new ArgumentNullException(nameof(delimiters));
+            this.delimiters = delimiters;
+        }
+
+        public string[] Chunk(string str)
+        {
+            var list = new List<string>();
+            int begin = 0;
+            bool processingDelim = false;
+            int delimBegin = 0;
+            for (int i = 0; i < str.Length; i++)
+            {
+                if (Array.IndexOf(delimiters, str[i]) != -1)
+                {
+                    if (i >= str.Length - 1)
+                    {
+                        if (processingDelim)
+                        {
+                            list.Add(str.Substring(delimBegin, (i + 1 - delimBegin)));
+                        }
+                        else
+                        {
+                            list.Add(str.Substring(begin, (i - begin)));
+                            list.Add(str.Substring(i, 1));
+                        }
+                    }
+                    else
+                    {
+                        if (!processingDelim)
+                        {
+                            list.Add(str.Substring(begin, (i - begin)));
+                            processingDelim = true;
+                            delimBegin = i;
+                        }
+                    }
+
+                    begin = i + 1;
+                }
+                else
+                {
+                    if (processingDelim)
+                    {
+                        if (i - delimBegin > 0)
+                        {
+                            list.Add(str.Substring(delimBegin, (i - delimBegin)));
+                        }
+
+                        processingDelim = false;
+                    }
+
+                    if (i >= str.Length - 1)
+                    {
+                        list.Add(str.Substring(begin, (i + 1 - begin)));
+                    }
+                }
+            }
+
+            return list.ToArray();
+        }
+    }
+}

--- a/DiffPlex/Chunkers/LineChunker.cs
+++ b/DiffPlex/Chunkers/LineChunker.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace DiffPlex.Chunkers
+{
+    public class LineChunker:IChunker
+    {
+        private readonly string[] lineSeparators = new[] {"\r\n", "\r", "\n"};
+
+        public string[] Chunk(string text)
+        {
+            return text.Split(lineSeparators, StringSplitOptions.None);
+        }
+    }
+}

--- a/DiffPlex/Chunkers/LineEndingsPreservingChunker.cs
+++ b/DiffPlex/Chunkers/LineEndingsPreservingChunker.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+
+namespace DiffPlex.Chunkers
+{
+    public class LineEndingsPreservingChunker:IChunker
+    {
+        private readonly string[] emptyArray = new string[0];
+        public string[] Chunk(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return emptyArray;
+
+            var output = new List<string>();
+            var lastCut = 0;
+            for (var currentPosition = 0; currentPosition < text.Length; currentPosition++)
+            {
+                char ch = text[currentPosition];
+                switch (ch)
+                {
+                    case '\n':
+                    case '\r':
+                        currentPosition++;
+                        if (ch == '\r' && currentPosition < text.Length && text[currentPosition] == '\n')
+                        {
+                            currentPosition++;
+                        }
+                        var str = text.Substring(lastCut, currentPosition - lastCut);
+                        lastCut = currentPosition;
+                        output.Add(str);
+                        break;
+                    default:
+                        continue;
+                }
+            }
+
+            if (lastCut != text.Length)
+            {
+                var str = text.Substring(lastCut, text.Length - lastCut);
+                output.Add(str);
+            }
+
+            return output.ToArray();
+        }
+    }
+}

--- a/DiffPlex/Chunkers/WordChunker.cs
+++ b/DiffPlex/Chunkers/WordChunker.cs
@@ -1,0 +1,11 @@
+﻿namespace DiffPlex.Chunkers
+{
+    public class WordChunker:DelimiterChunker
+    {
+        private static char[] WordSeparaters { get; } = { ' ', '\t', '.', '(', ')', '{', '}', ',', '!' };
+
+        public WordChunker() : base(WordSeparaters)
+        {
+        }
+    }
+}

--- a/DiffPlex/DiffBuilder/IInlineDiffBuilder.cs
+++ b/DiffPlex/DiffBuilder/IInlineDiffBuilder.cs
@@ -5,5 +5,6 @@ namespace DiffPlex.DiffBuilder
     public interface IInlineDiffBuilder
     {
         DiffPaneModel BuildDiffModel(string oldText, string newText);
+        DiffPaneModel BuildDiffModel(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase, IChunker chunker);
     }
 }

--- a/DiffPlex/DiffBuilder/InlineDiffBuilder.cs
+++ b/DiffPlex/DiffBuilder/InlineDiffBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using DiffPlex.Chunkers;
 using DiffPlex.DiffBuilder.Model;
 using DiffPlex.Model;
 
@@ -19,11 +20,18 @@ namespace DiffPlex.DiffBuilder
 
         public DiffPaneModel BuildDiffModel(string oldText, string newText, bool ignoreWhitespace)
         {
+            var chunker = new LineChunker();
+            return BuildDiffModel(oldText, newText, ignoreWhitespace, false, chunker);
+        }
+
+        public DiffPaneModel BuildDiffModel(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase, IChunker chunker)
+        {
             if (oldText == null) throw new ArgumentNullException(nameof(oldText));
             if (newText == null) throw new ArgumentNullException(nameof(newText));
 
             var model = new DiffPaneModel();
-            var diffResult = differ.CreateLineDiffs(oldText, newText, ignoreWhitespace);
+
+            var diffResult = differ.CreateDiffs(oldText, newText, ignoreWhitespace, ignoreCase: ignoreCase, chunker);
             BuildDiffPieces(diffResult, model.Lines);
             return model;
         }

--- a/DiffPlex/Differ.cs
+++ b/DiffPlex/Differ.cs
@@ -7,53 +7,50 @@ namespace DiffPlex
 {
     public class Differ : IDiffer
     {
-        private readonly IChunker lineChunker = new LineChunker();
-        private readonly IChunker characterChunker = new CharacterChunker();
 
         private static readonly string[] emptyStringArray = new string[0];
 
         public DiffResult CreateLineDiffs(string oldText, string newText, bool ignoreWhitespace)
         {
-            return CreateLineDiffs(oldText, newText, ignoreWhitespace, false);
+            return CreateDiffs(oldText, newText, ignoreWhitespace, false, new LineChunker());
         }
 
         public DiffResult CreateLineDiffs(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase)
         {
-            return CreateCustomDiffs(oldText, newText, ignoreWhitespace, ignoreCase, lineChunker);
+            return CreateDiffs(oldText, newText, ignoreWhitespace, ignoreCase, new LineChunker());
         }
 
         public DiffResult CreateCharacterDiffs(string oldText, string newText, bool ignoreWhitespace)
         {
-            return CreateCharacterDiffs(oldText, newText, ignoreWhitespace, false);
+            return CreateDiffs(oldText, newText, ignoreWhitespace, false, new CharacterChunker());
         }
 
         public DiffResult CreateCharacterDiffs(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase)
         {
-            return CreateCustomDiffs(oldText, newText, ignoreWhitespace, ignoreCase, characterChunker );
+            return CreateDiffs(oldText, newText, ignoreWhitespace, ignoreCase, new CharacterChunker());
         }
 
         public DiffResult CreateWordDiffs(string oldText, string newText, bool ignoreWhitespace, char[] separators)
         {
-            return CreateWordDiffs(oldText, newText, ignoreWhitespace, false, separators);
+            return CreateDiffs(oldText, newText, ignoreWhitespace, false, new DelimiterChunker(separators));
         }
 
         public DiffResult CreateWordDiffs(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase, char[] separators)
         {
-            var delimiterChunker = new DelimiterChunker(separators);
-            return CreateCustomDiffs(oldText, newText, ignoreWhitespace, ignoreCase, delimiterChunker);
+            return CreateDiffs(oldText, newText, ignoreWhitespace, ignoreCase, new DelimiterChunker(separators));
         }
 
         public DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, Func<string, string[]> chunker)
         {
-            return CreateCustomDiffs(oldText, newText, ignoreWhiteSpace, false, chunker);
+            return CreateDiffs(oldText, newText, ignoreWhiteSpace, false, new CustomFunctionChunker(chunker));
         }
 
         public DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase, Func<string, string[]> chunker)
         {
-            return CreateCustomDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, new CustomFunctionChunker(chunker));
+            return CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, new CustomFunctionChunker(chunker));
         }
 
-        public DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase, IChunker chunker)
+        public DiffResult CreateDiffs(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase, IChunker chunker)
         {
             if (oldText == null) throw new ArgumentNullException(nameof(oldText));
             if (newText == null) throw new ArgumentNullException(nameof(newText));
@@ -102,7 +99,7 @@ namespace DiffPlex
 
             return new DiffResult(modOld.Pieces, modNew.Pieces, lineDiffs);
         }
-       
+
         /// <summary>
         /// Finds the middle snake and the minimum length of the edit script comparing string A and B
         /// </summary>

--- a/DiffPlex/IChunker.cs
+++ b/DiffPlex/IChunker.cs
@@ -2,6 +2,9 @@
 {
     public interface IChunker
     {
+        /// <summary>
+        /// Dive text into sub-parts
+        /// </summary>
         string[] Chunk(string text);
     }
 }

--- a/DiffPlex/IChunker.cs
+++ b/DiffPlex/IChunker.cs
@@ -1,0 +1,7 @@
+﻿namespace DiffPlex
+{
+    public interface IChunker
+    {
+        string[] Chunk(string text);
+    }
+}

--- a/DiffPlex/IDiffer.cs
+++ b/DiffPlex/IDiffer.cs
@@ -4,7 +4,7 @@ using DiffPlex.Model;
 namespace DiffPlex
 {
     /// <summary>
-    /// Provides methods for generate differences between texts
+    /// Responsible for generating differences between texts
     /// </summary>
     public interface IDiffer
     {
@@ -16,6 +16,16 @@ namespace DiffPlex
         DiffResult CreateWordDiffs(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase, char[] separators);
         DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, Func<string, string[]> chunker);
         DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase, Func<string, string[]> chunker);
-        DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase, IChunker chunker);
+
+        /// <summary>
+        /// Create a diff by comparing text line by line
+        /// </summary>
+        /// <param name="oldText">The old text.</param>
+        /// <param name="newText">The new text.</param>
+        /// <param name="ignoreWhiteSpace">if set to <c>true</c> will ignore white space when determining if lines are the same.</param>
+        /// <param name="ignoreCase">Determine if the text comparision is case sensitive or not</param>
+        /// <param name="chunker">Component responsible for tokenizing the compared texts</param>
+        /// <returns>A DiffResult object which details the differences</returns>
+        DiffResult CreateDiffs(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase, IChunker chunker);
     }
 }

--- a/DiffPlex/IDiffer.cs
+++ b/DiffPlex/IDiffer.cs
@@ -8,13 +8,28 @@ namespace DiffPlex
     /// </summary>
     public interface IDiffer
     {
+        [Obsolete("Use CreateDiffs method instead", false)]
         DiffResult CreateLineDiffs(string oldText, string newText, bool ignoreWhitespace);
+        
+        [Obsolete("Use CreateDiffs method instead", false)]
         DiffResult CreateLineDiffs(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase);
+        
+        [Obsolete("Use CreateDiffs method instead", false)]
         DiffResult CreateCharacterDiffs(string oldText, string newText, bool ignoreWhitespace);
+        
+        [Obsolete("Use CreateDiffs method instead", false)]
         DiffResult CreateCharacterDiffs(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase);
+        
+        [Obsolete("Use CreateDiffs method instead", false)]
         DiffResult CreateWordDiffs(string oldText, string newText, bool ignoreWhitespace, char[] separators);
+        
+        [Obsolete("Use CreateDiffs method instead", false)]
         DiffResult CreateWordDiffs(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase, char[] separators);
+        
+        [Obsolete("Use CreateDiffs method instead", false)]
         DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, Func<string, string[]> chunker);
+        
+        [Obsolete("Use CreateDiffs method instead", false)] 
         DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase, Func<string, string[]> chunker);
 
         /// <summary>

--- a/DiffPlex/IDiffer.cs
+++ b/DiffPlex/IDiffer.cs
@@ -16,5 +16,6 @@ namespace DiffPlex
         DiffResult CreateWordDiffs(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase, char[] separators);
         DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, Func<string, string[]> chunker);
         DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase, Func<string, string[]> chunker);
+        DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase, IChunker chunker);
     }
 }

--- a/Facts.DiffPlex/Chunkers/LineEndingsPreservingChunkerFacts.cs
+++ b/Facts.DiffPlex/Chunkers/LineEndingsPreservingChunkerFacts.cs
@@ -1,0 +1,78 @@
+﻿using DiffPlex.Chunkers;
+using Xunit;
+
+namespace Facts.DiffPlex.Chunkers
+{
+    public class LineEndingsPreservingChunkerFacts
+    {
+        [Fact]
+        public void should_split_lines_when_first_line_empty()
+        {
+            //ARRANGE
+            var chunker = new LineEndingsPreservingChunker();
+            var sampleText = "\r\nFirst\r\nSecond\r\nLast\r\n";
+
+            //ACT
+            var chunks = chunker.Chunk(sampleText);
+
+            //ASSERT
+            Assert.Equal(4, chunks.Length);
+            Assert.Equal("\r\n", chunks[0]);
+            Assert.Equal("First\r\n", chunks[1]);
+            Assert.Equal("Second\r\n", chunks[2]);
+            Assert.Equal("Last\r\n", chunks[3]);
+        }
+
+        [Fact]
+        public void should_split_lines_when_last_does_not_end_with_lineending()
+        {
+            //ARRANGE
+            var chunker = new LineEndingsPreservingChunker();
+            var sampleText = "First\r\nSecond\r\nLast";
+
+            //ACT
+            var chunks = chunker.Chunk(sampleText);
+
+            //ASSERT
+            Assert.Equal(3, chunks.Length);
+            Assert.Equal("First\r\n", chunks[0]);
+            Assert.Equal("Second\r\n", chunks[1]);
+            Assert.Equal("Last", chunks[2]);
+        }
+
+        [Fact]
+        public void should_split_when_all_lines_are_empty()
+        {
+            //ARRANGE
+            var chunker = new LineEndingsPreservingChunker();
+            var sampleText = "\r\n\r\n\r\n";
+
+            //ACT
+            var chunks = chunker.Chunk(sampleText);
+
+            //ASSERT
+            Assert.Equal(3, chunks.Length);
+            Assert.Equal("\r\n", chunks[0]);
+            Assert.Equal("\r\n", chunks[1]);
+            Assert.Equal("\r\n", chunks[2]);
+        }
+
+        [Fact]
+        public void should_split_when_different_line_ending()
+        {
+            //ARRANGE
+            var chunker = new LineEndingsPreservingChunker();
+            var sampleText = "\r\nFirst\nSecond\rLast";
+
+            //ACT
+            var chunks = chunker.Chunk(sampleText);
+
+            //ASSERT
+            Assert.Equal(4, chunks.Length);
+            Assert.Equal("\r\n", chunks[0]);
+            Assert.Equal("First\n", chunks[1]);
+            Assert.Equal("Second\r", chunks[2]);
+            Assert.Equal("Last", chunks[3]);
+        }
+    }
+}

--- a/Facts.DiffPlex/DifferFacts.cs
+++ b/Facts.DiffPlex/DifferFacts.cs
@@ -12,27 +12,6 @@ namespace Facts.DiffPlex
     {
         public class CreateCustomDiffs
         {
-            [Fact]
-            public void Will_throw_if_oldText_is_null()
-            {
-                var differ = new TestableDiffer();
-
-                var ex = Record.Exception(() => differ.CreateCustomDiffs(null, "someString", false, null)) as ArgumentNullException;
-
-                Assert.NotNull(ex);
-                Assert.Equal("oldText", ex.ParamName);
-            }
-
-            [Fact]
-            public void Will_throw_if_newText_is_null()
-            {
-                var differ = new TestableDiffer();
-
-                var ex = Record.Exception(() => differ.CreateCustomDiffs("someString", null, false, null)) as ArgumentNullException;
-
-                Assert.NotNull(ex);
-                Assert.Equal("newText", ex.ParamName);
-            }
 
             [Fact]
             public void Will_throw_if_chunker_is_null()

--- a/Facts.DiffPlex/DifferFacts.cs
+++ b/Facts.DiffPlex/DifferFacts.cs
@@ -42,7 +42,7 @@ namespace Facts.DiffPlex
                 var ex = Record.Exception(() => differ.CreateCustomDiffs("someString", "otherString", false, null)) as ArgumentNullException;
 
                 Assert.NotNull(ex);
-                Assert.Equal("chunker", ex.ParamName);
+                Assert.Equal("customChunkerFunc", ex.ParamName);
             }
         }
 

--- a/Facts.DiffPlex/InlineDiffBuilderFacts.cs
+++ b/Facts.DiffPlex/InlineDiffBuilderFacts.cs
@@ -58,7 +58,7 @@ namespace Facts.DiffPlex
                 string text = "a\nb\nc\nd\n\n";
                 string[] textLines = { "a", "b", "c", "d", "" };
                 var differ = new Mock<IDiffer>();
-                differ.Setup(x => x.CreateLineDiffs(text, text, true))
+                differ.Setup(x => x.CreateDiffs(text, text, true, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(textLines, textLines, new List<DiffBlock>() { new DiffBlock(0, 0, 5, 0) }));
                 var builder = new InlineDiffBuilder(differ.Object);
 
@@ -82,7 +82,7 @@ namespace Facts.DiffPlex
                 string[] textLinesOld = { };
                 string[] textLinesNew = { "z", "y" };
                 var differ = new Mock<IDiffer>();
-                differ.Setup(x => x.CreateLineDiffs(textOld, textNew, true))
+                differ.Setup(x => x.CreateDiffs(textOld, textNew, true, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(textLinesOld, textLinesNew, new List<DiffBlock> { new DiffBlock(0, 0, 0, 2) }));
                 var builder = new InlineDiffBuilder(differ.Object);
 
@@ -107,7 +107,7 @@ namespace Facts.DiffPlex
                 string[] textLinesNew = { };
                 string[] textLinesOld = { "z", "y" };
                 var differ = new Mock<IDiffer>();
-                differ.Setup(x => x.CreateLineDiffs(textOld, textNew, true))
+                differ.Setup(x => x.CreateDiffs(textOld, textNew, true,false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(textLinesOld, textLinesNew, new List<DiffBlock> { new DiffBlock(0, 2, 0, 0) }));
                 var builder = new InlineDiffBuilder(differ.Object);
 
@@ -132,7 +132,7 @@ namespace Facts.DiffPlex
                 string[] textLinesOld = { "a", "b", "c", "d", "" };
                 string[] textLinesNew = { "z", "y", "x", "w" };
                 var differ = new Mock<IDiffer>();
-                differ.Setup(x => x.CreateLineDiffs(textOld, textNew, true))
+                differ.Setup(x => x.CreateDiffs(textOld, textNew, true, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(textLinesOld, textLinesNew, new List<DiffBlock> { new DiffBlock(0, 5, 0, 4) }));
                 var builder = new InlineDiffBuilder(differ.Object);
 
@@ -170,7 +170,7 @@ namespace Facts.DiffPlex
                 string[] textLinesOld = { "1", "2", "a", "b", "c", "d", "e", "f" };
                 string[] textLinesNew = { "1", "2", "z", "y", "x", "w", "e", "f" };
                 var differ = new Mock<IDiffer>();
-                differ.Setup(x => x.CreateLineDiffs(textOld, textNew, true))
+                differ.Setup(x => x.CreateDiffs(textOld, textNew, true, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(textLinesOld, textLinesNew, new List<DiffBlock> { new DiffBlock(2, 4, 2, 4) }));
                 var builder = new InlineDiffBuilder(differ.Object);
 
@@ -216,7 +216,7 @@ namespace Facts.DiffPlex
                 string[] textLinesOld = { "1", "2", "a", "b", "c", "d", "e", "f" };
                 string[] textLinesNew = { "1", "2", "z", "y", "c", "w", "e", "f" };
                 var differ = new Mock<IDiffer>();
-                differ.Setup(x => x.CreateLineDiffs(textOld, textNew, true))
+                differ.Setup(x => x.CreateDiffs(textOld, textNew, true, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(textLinesOld, textLinesNew, new List<DiffBlock> { new DiffBlock(2, 2, 2, 2), new DiffBlock(5, 1, 5, 1) }));
                 var builder = new InlineDiffBuilder(differ.Object);
 

--- a/Facts.DiffPlex/SideBySideDiffBuilderFacts.cs
+++ b/Facts.DiffPlex/SideBySideDiffBuilderFacts.cs
@@ -22,26 +22,6 @@ namespace Facts.DiffPlex
                 var an = (ArgumentNullException) ex;
                 Assert.Equal("differ", an.ParamName);
             }
-
-            [Fact]
-            public void Will_throw_is_Separators_is_null()
-            {
-                var ex = Record.Exception(() => new SideBySideDiffBuilder(new Differ(), null));
-
-                Assert.IsType<ArgumentException>(ex);
-                var an = (ArgumentException)ex;
-                Assert.Equal("wordSeparators", an.ParamName);
-            }
-
-            [Fact]
-            public void Will_throw_is_Separators_is_empty()
-            {
-                var ex = Record.Exception(() => new SideBySideDiffBuilder(new Differ(), new char[] { }));
-
-                Assert.IsType<ArgumentException>(ex);
-                var an = (ArgumentException)ex;
-                Assert.Equal("wordSeparators", an.ParamName);
-            }
         }
 
         public class BuildDiffModel
@@ -72,56 +52,15 @@ namespace Facts.DiffPlex
                 Assert.Equal("newText", an.ParamName);
             }
 
-
-            [Fact]
-            public void Will_pass_correct_word_separators_to_create_word_diff()
-            {
-                string text = "a\nb\nc\nd\n\n";
-                string[] textLines = {"a", "b", "c", "d", ""};
-                char[] chars = null;
-                var differ = new Mock<IDiffer>();
-                differ.Setup(x => x.CreateLineDiffs(text, text, true))
-                    .Returns(new DiffResult(textLines, textLines, new List<DiffBlock> {new DiffBlock(1, 1, 1, 1)}));
-                differ.Setup(x => x.CreateWordDiffs(It.IsAny<string>(), It.IsAny<string>(), false, It.IsAny<char[]>()))
-                    .Returns(new DiffResult(new string[0], new string[0], new List<DiffBlock>()))
-                    .Callback<string, string, bool, char[]>((a, b, c, d) => chars = d);
-                var builder = new SideBySideDiffBuilder(differ.Object);
-
-                builder.BuildDiffModel(text, text);
-
-                Assert.Equal(builder.WordSeparaters.Length, chars.Length);
-                foreach (var c in builder.WordSeparaters)
-                {
-                    Assert.Contains(c, chars);
-                }
-            }
-
-            [Fact]
-            public void Will_pass_correct_word_separators_to_constructor_to_create_word_diff()
-            {
-                string text = "a\nb\nc\nd\n\n";
-                string[] textLines = { "a", "b", "c", "d", "" };
-                char[] chars = { ' ', '.' };
-                var builder = new SideBySideDiffBuilder(new Differ(), chars);
-
-                builder.BuildDiffModel(text, text);
-
-                Assert.Equal(builder.WordSeparaters.Length, chars.Length);
-                foreach (var c in builder.WordSeparaters)
-                {
-                    Assert.Contains(c, chars);
-                }
-            }
-
             [Fact]
             public void Will_build_diffModel_for_duplicate_strings()
             {
                 string text = "a\nb\nc\nd\n\n";
                 string[] textLines = {"a", "b", "c", "d", ""};
                 var differ = new Mock<IDiffer>();
-                differ.Setup(x => x.CreateLineDiffs(text, text, true))
+                differ.Setup(x => x.CreateDiffs(text, text, true, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(textLines, textLines, new List<DiffBlock>()));
-                differ.Setup(x => x.CreateWordDiffs(It.IsAny<string>(), It.IsAny<string>(), false, It.IsAny<char[]>()))
+                differ.Setup(x => x.CreateDiffs(It.IsAny<string>(), It.IsAny<string>(), false, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(new string[0], new string[0], new List<DiffBlock>()));
                 var builder = new SideBySideDiffBuilder(differ.Object);
 
@@ -149,9 +88,9 @@ namespace Facts.DiffPlex
                 string[] textLinesOld = {};
                 string[] textLinesNew = {"z", "y"};
                 var differ = new Mock<IDiffer>();
-                differ.Setup(x => x.CreateLineDiffs(textOld, textNew, true))
+                differ.Setup(x => x.CreateDiffs(textOld, textNew, true, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(textLinesOld, textLinesNew, new List<DiffBlock> {new DiffBlock(0, 0, 0, 2)}));
-                differ.Setup(x => x.CreateWordDiffs(It.IsAny<string>(), It.IsAny<string>(), false, It.IsAny<char[]>()))
+                differ.Setup(x => x.CreateDiffs(It.IsAny<string>(), It.IsAny<string>(), false, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(new string[0], new string[0], new List<DiffBlock>()));
                 var builder = new SideBySideDiffBuilder(differ.Object);
 
@@ -181,7 +120,7 @@ namespace Facts.DiffPlex
                 string[] textLinesNew = {};
                 string[] textLinesOld = {"z", "y"};
                 var differ = new Mock<IDiffer>();
-                differ.Setup(x => x.CreateLineDiffs(textOld, textNew, true))
+                differ.Setup(x => x.CreateDiffs(textOld, textNew, true, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(textLinesOld, textLinesNew, new List<DiffBlock> {new DiffBlock(0, 2, 0, 0)}));
                 var builder = new SideBySideDiffBuilder(differ.Object);
 
@@ -211,9 +150,9 @@ namespace Facts.DiffPlex
                 string[] textLinesOld = {"a", "b", "c", "d", ""};
                 string[] textLinesNew = {"z", "y", "x", "w"};
                 var differ = new Mock<IDiffer>();
-                differ.Setup(x => x.CreateLineDiffs(textOld, textNew, true))
+                differ.Setup(x => x.CreateDiffs(textOld, textNew, true, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(textLinesOld, textLinesNew, new List<DiffBlock> {new DiffBlock(0, 5, 0, 4)}));
-                differ.Setup(x => x.CreateWordDiffs(It.IsAny<string>(), It.IsAny<string>(), false, It.IsAny<char[]>()))
+                differ.Setup(x => x.CreateDiffs(It.IsAny<string>(), It.IsAny<string>(), false, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(new string[0], new string[0], new List<DiffBlock>()));
                 var builder = new SideBySideDiffBuilder(differ.Object);
 
@@ -270,9 +209,9 @@ namespace Facts.DiffPlex
                 string[] textLinesOld = {"1", "2", "a", "b", "c", "d", ""};
                 string[] textLinesNew = {"1", "2", "z", "y", "x", "w"};
                 var differ = new Mock<IDiffer>();
-                differ.Setup(x => x.CreateLineDiffs(textOld, textNew, true))
+                differ.Setup(x => x.CreateDiffs(textOld, textNew, true, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(textLinesOld, textLinesNew, new List<DiffBlock> {new DiffBlock(2, 5, 2, 4)}));
-                differ.Setup(x => x.CreateWordDiffs(It.IsAny<string>(), It.IsAny<string>(), false, It.IsAny<char[]>()))
+                differ.Setup(x => x.CreateDiffs(It.IsAny<string>(), It.IsAny<string>(), false, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(new string[0], new string[0], new List<DiffBlock>()));
                 var builder = new SideBySideDiffBuilder(differ.Object);
 
@@ -341,9 +280,9 @@ namespace Facts.DiffPlex
                 string[] textLinesOld = {"m is h"};
                 string[] textLinesNew = {"m ai is n h"};
                 var differ = new Mock<IDiffer>();
-                differ.Setup(x => x.CreateLineDiffs(textOld, textNew, true))
+                differ.Setup(x => x.CreateDiffs(textOld, textNew, true, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(textLinesOld, textLinesNew, new List<DiffBlock> {new DiffBlock(0, 1, 0, 1)}));
-                differ.Setup(x => x.CreateWordDiffs(It.IsAny<string>(), It.IsAny<string>(), false, It.IsAny<char[]>()))
+                differ.Setup(x => x.CreateDiffs(It.IsAny<string>(), It.IsAny<string>(), false, false, It.IsNotNull<IChunker>()))
                     .Returns(new DiffResult(
                                  new[] {"m ", "is ", "h"},
                                  new[] {"m ", "ai ", "is ", "n ", "h"},

--- a/README.md
+++ b/README.md
@@ -98,8 +98,40 @@ public interface IDiffer
     /// <param name="chunker">A function that will break the text into chunks.</param>
     /// <returns>A DiffResult object which details the differences</returns>
     DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, Func<string, string[]> chunker);
+
+            /// <summary>
+        /// Create a diff by comparing text line by line
+        /// </summary>
+        /// <param name="oldText">The old text.</param>
+        /// <param name="newText">The new text.</param>
+        /// <param name="ignoreWhiteSpace">if set to <c>true</c> will ignore white space when determining if lines are the same.</param>
+        /// <param name="ignoreCase">Determine if the text comparision is case sensitive or not</param>
+        /// <param name="chunker">Component responsible for tokenizing the compared texts</param>
+        /// <returns>A DiffResult object which details the differences</returns>
+        DiffResult CreateDiffs(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase, IChunker chunker);
 }
 ```
+
+## IChunker Interface
+
+```csharp
+public interface IChunker
+{
+    /// <summary>
+    /// Dive text into sub-parts
+    /// </summary>
+    string[] Chunk(string text);
+}
+```
+
+Currently provided implementations:
+- `CharacterChunker`
+- `CustomFunctionChunker`
+- `DelimiterChunker`
+- `LineChunker`
+- `LineEndingsPreservingChunker`
+- `WordChunker`
+
 
 ## ISidebySideDiffer Interface
 


### PR DESCRIPTION
Hi
This PR should fix #47. I've made also a small refactoring by introducing `IChunker` interface which simplifies the `DIffer`. In my opinion, the `IDiffer` interface should be cut to:

```csharp
DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase, IChunker chunker);
```

and the rest of the overloads should be implemented as the extension methods. IMHO the name should be also simplified, let's say `CreateDiff`. Of course, these are breaking changes so I want to discuss it at first.

__EDIT__: I realized that this not enough to fix the problem because `InlineDiffBuilder` has hardcoded an invocation of specific overload from `IDiffer`. I needed to go further and I made another refactor by making an `IChunker` a constructor dependency for `DIffer` class. Now the `API` is much simpler and the extensibility and testability has been improved.
