### PR TITLE
Exclude net35 reference assemblies from nuget package

### DIFF
--- a/DiffPlex/DiffPlex.csproj
+++ b/DiffPlex/DiffPlex.csproj
@@ -22,6 +22,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
     <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.0" />
   </ItemGroup>
 

--- a/DiffPlex/DiffPlex.csproj
+++ b/DiffPlex/DiffPlex.csproj
@@ -21,11 +21,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.0" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The `jnm2.ReferenceAssemblies.net35` is required only for the `net35` build, not for the other 2.

Both `jnm2.ReferenceAssemblies.net35` and `Microsoft.NETFramework.ReferenceAssemblies` is required for building the package and it's not necessary to publish a dependency on those libraries. Adding `PrivateAssets="All"` removes the dependency in the `.nuspec` file.