### PR TITLE
Change the property type of LineNumberWidthProperty to Int32

### DIFF
--- a/DiffPlex.Wpf/Controls/DiffViewer.xaml.cs
+++ b/DiffPlex.Wpf/Controls/DiffViewer.xaml.cs
@@ -81,7 +81,7 @@ namespace DiffPlex.Wpf.Controls
         /// <summary>
         /// The property of line number width.
         /// </summary>
-        public static readonly DependencyProperty LineNumberWidthProperty = RegisterDependencyProperty<double>(nameof(LineNumberWidth), 60, (d, e) =>
+        public static readonly DependencyProperty LineNumberWidthProperty = RegisterDependencyProperty(nameof(LineNumberWidth), 60, (d, e) =>
         {
             if (!(d is DiffViewer c) || e.OldValue == e.NewValue || !(e.NewValue is int n)) return;
             c.LeftContentPanel.LineNumberWidth = c.RightContentPanel.LineNumberWidth = c.InlineContentPanel.LineNumberWidth = n;

--- a/DiffPlex.Wpf/Controls/Helper.cs
+++ b/DiffPlex.Wpf/Controls/Helper.cs
@@ -33,7 +33,7 @@ namespace DiffPlex.Wpf.Controls
     internal static class Helper
     {
         private const int MaxCount = 3000;
-        public const string FontFamily = "Cascadia Code, Consolas, Courier New, monospace, Microsoft Yahei, Segoe UI Emoji, Segoe UI Symbol";
+        public const string FontFamily = "Cascadia Code, Consolas, Courier New, monospace, Microsoft Yahei, Microsoft Jhenghei, Meiryo, Segoe UI, Segoe UI Emoji, Segoe UI Symbol";
 
         /// <summary>
         /// Updates the inline diffs view.

--- a/DiffPlex.Wpf/Controls/InlineDiffViewer.xaml.cs
+++ b/DiffPlex.Wpf/Controls/InlineDiffViewer.xaml.cs
@@ -52,7 +52,7 @@ namespace DiffPlex.Wpf.Controls
         /// <summary>
         /// The property of line number.
         /// </summary>
-        public static readonly DependencyProperty LineNumberWidthProperty = RegisterDependencyProperty<double>(nameof(LineNumberWidth), 60, (d, e) =>
+        public static readonly DependencyProperty LineNumberWidthProperty = RegisterDependencyProperty(nameof(LineNumberWidth), 60, (d, e) =>
         {
             if (!(d is InlineDiffViewer c) || e.OldValue == e.NewValue || !(e.NewValue is int n)) return;
             c.ContentPanel.LineNumberWidth = n;
@@ -167,6 +167,11 @@ namespace DiffPlex.Wpf.Controls
             get => (DiffPaneModel)GetValue(DiffModelProperty);
             set => SetValue(DiffModelProperty, value);
         }
+
+        /// <summary>
+        /// Gets the lines in the diff model.
+        /// </summary>
+        public IReadOnlyList<DiffPiece> Lines => DiffModel?.Lines?.AsReadOnly();
 
         /// <summary>
         /// Gets or sets the foreground brush of the line number.

--- a/DiffPlex.Wpf/Controls/SideBySideDiffViewer.xaml.cs
+++ b/DiffPlex.Wpf/Controls/SideBySideDiffViewer.xaml.cs
@@ -52,7 +52,7 @@ namespace DiffPlex.Wpf.Controls
         /// <summary>
         /// The property of line number width.
         /// </summary>
-        public static readonly DependencyProperty LineNumberWidthProperty = RegisterDependencyProperty<double>(nameof(LineNumberWidth), 60, (d, e) =>
+        public static readonly DependencyProperty LineNumberWidthProperty = RegisterDependencyProperty(nameof(LineNumberWidth), 60, (d, e) =>
         {
             if (!(d is SideBySideDiffViewer c) || e.OldValue == e.NewValue || !(e.NewValue is int n)) return;
             c.LeftContentPanel.LineNumberWidth = c.RightContentPanel.LineNumberWidth = n;
@@ -207,6 +207,16 @@ namespace DiffPlex.Wpf.Controls
             get => (SideBySideDiffModel)GetValue(DiffModelProperty);
             set => SetValue(DiffModelProperty, value);
         }
+
+        /// <summary>
+        /// Gets the old text.
+        /// </summary>
+        public DiffPaneModel OldText => DiffModel?.OldText;
+
+        /// <summary>
+        /// Gets the new text.
+        /// </summary>
+        public DiffPaneModel NewText => DiffModel?.NewText;
 
         /// <summary>
         /// Gets or sets the foreground brush of the line number.

--- a/DiffPlex.Wpf/DiffPlex.Wpf.csproj
+++ b/DiffPlex.Wpf/DiffPlex.Wpf.csproj
@@ -4,14 +4,14 @@
     <TargetFrameworks>net5.0-windows;netcoreapp3.1;net46;net48</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <RootNamespace>DiffPlex.Wpf</RootNamespace>
     <AssemblyName>DiffPlex.Wpf</AssemblyName>
     <PackageTags>diff, wpf</PackageTags>
     <Description>DiffPlex.Wpf is a WPF control library that allows you to programatically render visual text diffs in your application. It also provide a diff viewer control used in Windows Forms application.</Description>
     <LangVersion>8.0</LangVersion>
-    <AssemblyVersion>1.3.1.0</AssemblyVersion>
-    <FileVersion>1.3.1.0</FileVersion>
+    <AssemblyVersion>1.3.2.0</AssemblyVersion>
+    <FileVersion>1.3.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix #81. Update the property type of `LineNumberWidthProperty` to `Int32` from `Double`.