### PR TITLE
Added new Diff on both DiffBuilders for more detailed DiffModel.

### DIFF
--- a/DiffPlex/DiffBuilder/InlineDiffBuilder.cs
+++ b/DiffPlex/DiffBuilder/InlineDiffBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using DiffPlex.Chunkers;
 using DiffPlex.DiffBuilder.Model;
 using DiffPlex.Model;
@@ -9,6 +10,8 @@ namespace DiffPlex.DiffBuilder
     public class InlineDiffBuilder : IInlineDiffBuilder
     {
         private readonly IDiffer differ;
+
+        private delegate ChangeType PieceBuilder(string oldText, string newText, List<DiffPiece> pieces, bool ignoreWhitespace, bool ignoreCase);
 
         /// <summary>
         /// Gets the default singleton instance of the inline diff builder.
@@ -76,6 +79,130 @@ namespace DiffPlex.DiffBuilder
             
             return model;
         }
+
+        public static DiffPaneModel Diff(
+            IDiffer differ, 
+            string oldText, string newText,
+            List<IChunker> detailsPack,
+            bool ignoreWhiteSpace = true, bool ignoreCase = false)
+        {
+            if (oldText == null) throw new ArgumentNullException(nameof(oldText));
+            if (newText == null) throw new ArgumentNullException(nameof(newText));
+
+            if (differ == null) return Diff(oldText, newText, ignoreWhiteSpace, ignoreCase);
+
+            LinkedList<IChunker> chunkers;
+            if (detailsPack == null || !detailsPack.Any())
+            {
+                chunkers = new LinkedList<IChunker>();
+                chunkers.AddLast(DiffPlex.Chunkers.LineChunker.Instance);
+                chunkers.AddLast(DiffPlex.Chunkers.WordChunker.Instance);
+                chunkers.AddLast(DiffPlex.Chunkers.CharacterChunker.Instance);
+            }
+            else
+            {
+                chunkers = new LinkedList<IChunker>(detailsPack);
+            }
+
+            var model = new DiffPaneModel();
+            var cnode = chunkers.First;
+            var diffResult = differ.CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, cnode.Value);
+            BuildDiffPieces(diffResult, model.Lines, NextPieceBuilderInternal(differ, cnode.Next), ignoreWhiteSpace, ignoreCase);
+
+            return model;
+        }
+
+
+        private static PieceBuilder NextPieceBuilderInternal(
+            IDiffer differ,
+            LinkedListNode<IChunker> chunkerNode)
+        {
+            if (chunkerNode == null)
+            {
+                return null;
+            }
+            else
+            {
+                return (ot, nt, p, iw, ic) =>
+                {
+                    var r = differ.CreateDiffs(ot, nt, iw, ic, chunkerNode.Value);
+                    return BuildDiffPieces(r, p, NextPieceBuilderInternal(differ, chunkerNode.Next), iw, ic);
+                };
+            }
+        }
+
+        private static ChangeType BuildDiffPieces(
+            DiffResult diffResult, 
+            List<DiffPiece> pieces, PieceBuilder subPieceBuilder, 
+            bool ignoreWhiteSpace, bool ignoreCase)
+        {
+            int aPos = 0;
+            int bPos = 0;
+
+            ChangeType changeSummary = ChangeType.Unchanged;
+
+            foreach (var diffBlock in diffResult.DiffBlocks)
+            {
+                while (bPos < diffBlock.InsertStartB && aPos < diffBlock.DeleteStartA)
+                {
+                    pieces.Add(new DiffPiece(diffResult.PiecesOld[aPos], ChangeType.Unchanged, aPos + 1));
+                    aPos++;
+                    bPos++;
+                }
+
+                int i = 0;
+                for (; i < Math.Min(diffBlock.DeleteCountA, diffBlock.InsertCountB); i++)
+                {
+                    var piece = new DiffPiece(diffResult.PiecesOld[i + diffBlock.DeleteStartA], ChangeType.Deleted, aPos + 1);
+                    //var newPiece = new DiffPiece(diffResult.PiecesNew[i + diffBlock.InsertStartB], ChangeType.Inserted, bPos + 1);
+
+                    if (subPieceBuilder != null)
+                    {
+                        var subChangeSummary = subPieceBuilder(diffResult.PiecesOld[aPos], diffResult.PiecesNew[bPos], piece.SubPieces, ignoreWhiteSpace, ignoreCase);
+                        piece.Type = subChangeSummary;
+                    }
+
+                    pieces.Add(piece);
+                    aPos++;
+                    bPos++;
+                }
+
+                if (diffBlock.DeleteCountA > diffBlock.InsertCountB)
+                {
+                    for (; i < diffBlock.DeleteCountA; i++)
+                    {
+                        pieces.Add(new DiffPiece(diffResult.PiecesOld[i + diffBlock.DeleteStartA], ChangeType.Deleted, aPos + 1));
+
+                        aPos++;
+                    }
+                }
+                else
+                {
+                    for (; i < diffBlock.InsertCountB; i++)
+                    {
+                        pieces.Add(new DiffPiece(diffResult.PiecesNew[i + diffBlock.InsertStartB], ChangeType.Inserted, bPos + 1));
+
+                        bPos++;
+                    }
+                }
+            }
+
+            while (bPos < diffResult.PiecesNew.Length && aPos < diffResult.PiecesOld.Length)
+            {
+                pieces.Add(new DiffPiece(diffResult.PiecesOld[aPos], ChangeType.Unchanged, aPos + 1));
+                aPos++;
+                bPos++;
+            }
+
+            // Consider the whole diff as "modified" if we found any change, otherwise we consider it unchanged
+            if (pieces.Any(x => x.Type == ChangeType.Modified || x.Type == ChangeType.Inserted || x.Type == ChangeType.Deleted))
+            {
+                changeSummary = ChangeType.Modified;
+            }
+
+            return changeSummary;
+        }
+
 
         private static void BuildDiffPieces(DiffResult diffResult, List<DiffPiece> pieces)
         {

--- a/DiffPlex/DiffBuilder/Model/DiffPaneModel.cs
+++ b/DiffPlex/DiffBuilder/Model/DiffPaneModel.cs
@@ -1,10 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace DiffPlex.DiffBuilder.Model
 {
     public class DiffPaneModel
     {
+        public List<DiffPiece> Chunks => Lines;
+
         public List<DiffPiece> Lines { get; }
 
         public bool HasDifferences


### PR DESCRIPTION
See Issue #29

Added on both InlineDiffBuilder and SideBySideDiffBuilder possibility to add more details by providing a detailsPack of IChunker(s).

The InlineDiffBuilder on lowest level, is still missing the old / before char info. Didn't know where to put it: After or Under(SubPiece) the new / after char. Advice / help is welcome!

In order to not introduce any breaking changes in the API I introduced new Diff overload methods. These method(s) distinguish themselves by a detailsPack (Name oke?) that include the IChunkers to use. If null then default all 3 chunkers are used: Lines => Words => Characters.
 
Review comments are welcome!

Thanks for this great lib!