### PR TITLE
Massive performance improvement with large [25k+] documents in WPF.

### DIFF
--- a/DiffPlex.Wpf/Controls/InternalLinesViewer.xaml
+++ b/DiffPlex.Wpf/Controls/InternalLinesViewer.xaml
@@ -5,12 +5,18 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:DiffPlex.Wpf.Controls"
-             mc:Ignorable="d" 
+             mc:Ignorable="d" x:Name="lineViewer"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
         <ControlTemplate x:Key="LocalScrollViewerTemplate" TargetType="{x:Type ScrollViewer}">
             <Grid x:Name="Grid" Background="{TemplateBinding Background}">
-                <ScrollContentPresenter x:Name="PART_ScrollContentPresenter" CanContentScroll="{TemplateBinding CanContentScroll}" CanHorizontallyScroll="False" CanVerticallyScroll="False" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" Grid.Column="0" Margin="{TemplateBinding Padding}" Grid.Row="0"/>
+                <ScrollContentPresenter x:Name="PART_ScrollContentPresenter" CanContentScroll="{TemplateBinding CanContentScroll}" 
+                                        VirtualizingPanel.IsVirtualizing="True"
+                                        VirtualizingPanel.ScrollUnit="Pixel"
+                                        VirtualizingPanel.VirtualizationMode="Recycling" 
+                                        CanHorizontallyScroll="False" CanVerticallyScroll="False" 
+                                        ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" 
+                                        Grid.Column="0" Margin="{TemplateBinding Padding}" Grid.Row="0"/>
                 <ScrollBar x:Name="PART_VerticalScrollBar" AutomationProperties.AutomationId="VerticalScrollBar" Cursor="Arrow" HorizontalAlignment="Right" Maximum="{TemplateBinding ScrollableHeight}" Minimum="0" Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}" Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" ViewportSize="{TemplateBinding ViewportHeight}" Style="{DynamicResource LocalScrollBarStyle}" Background="#99808080" BorderBrush="#99808080" Foreground="#FF808080"/>
                 <ScrollBar x:Name="PART_HorizontalScrollBar" AutomationProperties.AutomationId="HorizontalScrollBar" Cursor="Arrow" VerticalAlignment="Bottom" Margin="0,0,20,0" Maximum="{TemplateBinding ScrollableWidth}" Minimum="0" Orientation="Horizontal" Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}" Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" ViewportSize="{TemplateBinding ViewportWidth}" Style="{DynamicResource LocalScrollBarStyle}" Background="#99808080" BorderBrush="#99808080" Foreground="#FF808080"/>
             </Grid>
@@ -256,6 +262,19 @@
                 </Trigger>
             </Style.Triggers>
         </Style>
+        <Style x:Key="TextBlockFontStyle" TargetType="{x:Type TextBlock}">
+        </Style>
+        <Style x:Key="ListBoxNoSelect" TargetType="{x:Type ListBoxItem}">
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="IsEnabled" Value="False"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Visibility" Value="{Binding Visible}"/>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="Transparent" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
     </UserControl.Resources>
     
     <Grid>
@@ -264,14 +283,113 @@
             <ColumnDefinition x:Name="OperationColumn" Width="20"/>
             <ColumnDefinition x:Name="ValueColumn" Width="1*"/>
         </Grid.ColumnDefinitions>
-        <ScrollViewer x:Name="NumberScrollViewer" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden" ScrollChanged="NumberScrollViewer_ScrollChanged">
-            <StackPanel x:Name="NumberPanel"/>
-        </ScrollViewer>
-        <ScrollViewer x:Name="OperationScrollViewer" Grid.Column="1" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden" ScrollChanged="OperationScrollViewer_ScrollChanged">
-            <StackPanel x:Name="OperationPanel"/>
-        </ScrollViewer>
-        <ScrollViewer Template="{DynamicResource LocalScrollViewerTemplate}" x:Name="ValueScrollViewer" Grid.Column="2" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" ScrollChanged="ValueScrollViewer_ScrollChanged" SizeChanged="ValueScrollViewer_SizeChanged">
-            <StackPanel x:Name="ValuePanel"/>
-        </ScrollViewer>
+        
+        <ListBox x:Name="NumberPanel" 
+                 ItemsSource="{Binding LineDetails,ElementName=lineViewer}" 
+                 VirtualizingStackPanel.VirtualizationMode="Recycling"
+                 VirtualizingStackPanel.ScrollUnit="Pixel"
+                 ScrollViewer.CanContentScroll="False"
+                 HorizontalContentAlignment="Stretch"
+                 ItemContainerStyle="{StaticResource ListBoxNoSelect}">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Path=Number}" TextAlignment="Right"
+                                Foreground="{Binding Path=NumberForeground, Mode=OneTime}"
+                                Background="{Binding Path=ChangeBackground, Mode=OneTime}"
+                                   
+                                FontSize="{Binding Path=FontSize,ElementName=lineViewer, Mode=OneTime}"
+                                FontFamily="{Binding Path=FontFamily,ElementName=lineViewer, Mode=OneTime}"
+                                FontWeight="{Binding Path=FontWeight,ElementName=lineViewer, Mode=OneTime}"
+                                FontStretch="{Binding Path=FontStretch,ElementName=lineViewer, Mode=OneTime}"
+                                FontStyle="{Binding Path=FontStyle,ElementName=lineViewer, Mode=OneTime}" />
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+            <ListBox.Template>
+                <ControlTemplate>
+                    <ScrollViewer x:Name="NumberScrollViewer" 
+                                    HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden" 
+                                    ScrollChanged="NumberScrollViewer_ScrollChanged">
+                        <ItemsPresenter/>
+                    </ScrollViewer>
+                </ControlTemplate>
+            </ListBox.Template>
+        </ListBox>
+
+        <ListBox x:Name="OperationPanel" Grid.Column="1"
+                 ItemsSource="{Binding LineDetails,ElementName=lineViewer}"
+                 VirtualizingStackPanel.VirtualizationMode="Recycling"
+                 VirtualizingStackPanel.ScrollUnit="Pixel"
+                 ScrollViewer.CanContentScroll="False"
+                 HorizontalContentAlignment="Stretch"
+                 ItemContainerStyle="{StaticResource ListBoxNoSelect}">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Path=Operation}" TextAlignment="Center"
+                                   Foreground="{Binding Path=ChangeForeground, Mode=OneTime}"
+                                   Background="{Binding Path=ChangeBackground, Mode=OneTime}"
+                                   
+                                   FontSize="{Binding Path=FontSize,ElementName=lineViewer,Mode=OneTime}"
+                                   FontFamily="{Binding Path=FontFamily,ElementName=lineViewer,Mode=OneTime}"
+                                   FontWeight="{Binding Path=FontWeight,ElementName=lineViewer,Mode=OneTime}"
+                                   FontStretch="{Binding Path=FontStretch,ElementName=lineViewer,Mode=OneTime}"
+                                   FontStyle="{Binding Path=FontStyle,ElementName=lineViewer,Mode=OneTime}" />
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+            <ListBox.Template>
+                <ControlTemplate>
+                    <ScrollViewer x:Name="OperationScrollViewer" 
+                                    HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden" 
+                                    ScrollChanged="OperationScrollViewer_ScrollChanged">
+                        <ItemsPresenter/>
+                    </ScrollViewer>
+                </ControlTemplate>
+            </ListBox.Template>
+        </ListBox>
+
+        <ListBox x:Name="ValuePanel" Grid.Column="2" 
+                 ItemsSource="{Binding LineDetails,ElementName=lineViewer}"
+                 VirtualizingStackPanel.VirtualizationMode="Recycling"
+                 VirtualizingStackPanel.ScrollUnit="Pixel"
+                 ScrollViewer.CanContentScroll="False"
+                 HorizontalContentAlignment="Stretch"
+                 ItemContainerStyle="{StaticResource ListBoxNoSelect}">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <ItemsControl ItemsSource="{Binding Segments}" BorderThickness="0">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal" 
+                                                Background="{Binding Path=ChangeBackground, Mode=OneTime}" 
+                                                ContextMenu="{Binding LineContextMenu,ElementName=lineViewer}"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Path=TextChunk}" 
+                                               Foreground="{Binding Path=SegmentForeground, Mode=OneTime}"
+                                               Background="{Binding Path=SegmentBackground, Mode=OneTime}"
+                                               
+                                               FontSize="{Binding Path=FontSize,ElementName=lineViewer,Mode=OneTime}"
+                                               FontFamily="{Binding Path=FontFamily,ElementName=lineViewer,Mode=OneTime}"
+                                               FontWeight="{Binding Path=FontWeight,ElementName=lineViewer,Mode=OneTime}"
+                                               FontStretch="{Binding Path=FontStretch,ElementName=lineViewer,Mode=OneTime}"
+                                               FontStyle="{Binding Path=FontStyle,ElementName=lineViewer,Mode=OneTime}" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+            <ListBox.Template>
+                <ControlTemplate>
+                    <ScrollViewer x:Name="ValueScrollViewer" 
+                                      Template="{DynamicResource LocalScrollViewerTemplate}"
+                                      HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" 
+                                      ScrollChanged="ValueScrollViewer_ScrollChanged"
+                                      SizeChanged="ValueScrollViewer_SizeChanged">
+                        <ItemsPresenter/>
+                    </ScrollViewer>
+                </ControlTemplate>
+            </ListBox.Template>
+        </ListBox>
     </Grid>
 </UserControl>

--- a/DiffPlex.Wpf/Controls/LineViewerLineData.cs
+++ b/DiffPlex.Wpf/Controls/LineViewerLineData.cs
@@ -1,0 +1,321 @@
+﻿using DiffPlex.DiffBuilder.Model;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Media;
+
+namespace DiffPlex.Wpf.Controls
+{
+
+    internal class LineViewerLineData : INotifyPropertyChanged
+    {
+        private Visibility visible;
+
+        //int? number, string operation, List<KeyValuePair<string, string>> value, string changeType, UIElement source
+        //int? number, string operation, string value, string changeType, UIElement source
+
+        public int? Number { get; set; }
+        public string Operation
+        {
+            get
+            {
+                switch (ChangeType)
+                {
+                    case ChangeType.Inserted: return "+";
+                    case ChangeType.Deleted: return "-";
+                }
+                return "";
+            }
+        }
+        public List<LineViewerSegment> Segments { get; set; }
+
+        public DiffPiece Piece { get; set; }
+
+
+        public ChangeType ChangeType { get; set; }
+        //TODO: Use styles properly instead of calculating color using this
+        public UIElement Source { get; set; }
+
+
+        public Brush FallbackForeground { get; internal set; } = null;
+
+        public Brush ChangeBackground
+        {
+            get
+            {
+                if (Source is DiffViewer)
+                {
+                    switch (ChangeType)
+                    {
+                        case ChangeType.Inserted:
+                            return (SolidColorBrush)Source.GetValue(DiffViewer.InsertedBackgroundProperty);
+                        case ChangeType.Deleted:
+                            return (SolidColorBrush)Source.GetValue(DiffViewer.DeletedBackgroundProperty);
+                        case ChangeType.Unchanged:
+                            return (SolidColorBrush)Source.GetValue(DiffViewer.UnchangedBackgroundProperty);
+                    }
+                }
+                else if (Source is InlineDiffViewer)
+                {
+                    switch (ChangeType)
+                    {
+                        case ChangeType.Inserted:
+                            return (SolidColorBrush)Source.GetValue(InlineDiffViewer.InsertedBackgroundProperty);
+                        case ChangeType.Deleted:
+                            return (SolidColorBrush)Source.GetValue(InlineDiffViewer.DeletedBackgroundProperty);
+                        case ChangeType.Unchanged:
+                            return (SolidColorBrush)Source.GetValue(InlineDiffViewer.UnchangedBackgroundProperty);
+                    }
+                }
+                else if (Source is SideBySideDiffViewer)
+                {
+                    switch (ChangeType)
+                    {
+                        case ChangeType.Inserted:
+                            return (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.InsertedBackgroundProperty);
+                        case ChangeType.Deleted:
+                            return (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.DeletedBackgroundProperty);
+                        case ChangeType.Unchanged:
+                            return (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.UnchangedBackgroundProperty);
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        public Brush NumberForeground
+        {
+            get
+            {
+                SolidColorBrush brushColor = null;
+
+                if (Source is DiffViewer)
+                {
+                    brushColor = (SolidColorBrush)Source.GetValue(DiffViewer.LineNumberForegroundProperty);
+                }
+                else if (Source is InlineDiffViewer)
+                {
+                    brushColor = (SolidColorBrush)Source.GetValue(InlineDiffViewer.LineNumberForegroundProperty);
+                }
+                else if (Source is SideBySideDiffViewer)
+                {
+                    brushColor = (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.LineNumberForegroundProperty);
+                }
+
+                return brushColor ?? FallbackForeground;
+            }
+        }
+
+        public Brush ChangeForeground
+        {
+            get
+            {
+                SolidColorBrush brushColor = null;
+
+                if (Source is DiffViewer)
+                {
+                    switch (ChangeType)
+                    {
+                        case ChangeType.Inserted:
+                            brushColor = (SolidColorBrush)Source.GetValue(DiffViewer.InsertedForegroundProperty);
+                            break;
+                        case ChangeType.Deleted:
+                            brushColor = (SolidColorBrush)Source.GetValue(DiffViewer.DeletedForegroundProperty);
+                            break;
+                        case ChangeType.Unchanged:
+                            brushColor = (SolidColorBrush)Source.GetValue(DiffViewer.UnchangedForegroundProperty);
+                            break;
+                        case ChangeType.Modified:
+                            brushColor = (SolidColorBrush)Source.GetValue(DiffViewer.ChangeTypeForegroundProperty);
+                            break;
+                    }
+                }
+                else if (Source is InlineDiffViewer)
+                {
+                    switch (ChangeType)
+                    {
+                        case ChangeType.Inserted:
+                            brushColor = (SolidColorBrush)Source.GetValue(InlineDiffViewer.InsertedForegroundProperty);
+                            break;
+                        case ChangeType.Deleted:
+                            brushColor = (SolidColorBrush)Source.GetValue(InlineDiffViewer.DeletedForegroundProperty);
+                            break;
+                        case ChangeType.Unchanged:
+                            brushColor = (SolidColorBrush)Source.GetValue(InlineDiffViewer.UnchangedForegroundProperty);
+                            break;
+                        case ChangeType.Modified:
+                            brushColor = (SolidColorBrush)Source.GetValue(InlineDiffViewer.ChangeTypeForegroundProperty);
+                            break;
+                    }
+                }
+                else if (Source is SideBySideDiffViewer)
+                {
+                    switch (ChangeType)
+                    {
+                        case ChangeType.Inserted:
+                            brushColor = (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.InsertedForegroundProperty);
+                            break;
+                        case ChangeType.Deleted:
+                            brushColor = (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.DeletedForegroundProperty);
+                            break;
+                        case ChangeType.Unchanged:
+                            brushColor = (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.UnchangedForegroundProperty);
+                            break;
+                        case ChangeType.Modified:
+                            brushColor = (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.ChangeTypeForegroundProperty);
+                            break;
+                    }
+                }
+
+                return brushColor ?? FallbackForeground;
+            }
+        }
+
+        public Visibility Visible
+        {
+            get => visible;
+            internal set
+            {
+                visible = value;
+                RaisePropertyChanged(nameof(Visible));
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void RaisePropertyChanged(string propertyName)
+        {
+            if (PropertyChanged != null)
+            {
+                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+    }
+
+    public class LineViewerSegment
+    {
+        public string TextChunk { get; set; }
+        public ChangeType ChunkChange { get; set; }
+
+
+
+        public UIElement Source { get; set; }
+        public Brush FallbackForeground { get; internal set; } = null;
+
+        public Brush SegmentBackground
+        {
+            get
+            {
+                if (Source is DiffViewer)
+                {
+                    switch (ChunkChange)
+                    {
+                        case ChangeType.Inserted:
+                            return (SolidColorBrush)Source.GetValue(DiffViewer.InsertedBackgroundProperty);
+                        case ChangeType.Deleted:
+                            return (SolidColorBrush)Source.GetValue(DiffViewer.DeletedBackgroundProperty);
+                        case ChangeType.Unchanged:
+                            return (SolidColorBrush)Source.GetValue(DiffViewer.UnchangedBackgroundProperty);
+                    }
+                }
+                else if (Source is InlineDiffViewer)
+                {
+                    switch (ChunkChange)
+                    {
+                        case ChangeType.Inserted:
+                            return (SolidColorBrush)Source.GetValue(InlineDiffViewer.InsertedBackgroundProperty);
+                        case ChangeType.Deleted:
+                            return (SolidColorBrush)Source.GetValue(InlineDiffViewer.DeletedBackgroundProperty);
+                        case ChangeType.Unchanged:
+                            return (SolidColorBrush)Source.GetValue(InlineDiffViewer.UnchangedBackgroundProperty);
+                    }
+                }
+                else if (Source is SideBySideDiffViewer)
+                {
+                    switch (ChunkChange)
+                    {
+                        case ChangeType.Inserted:
+                            return (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.InsertedBackgroundProperty);
+                        case ChangeType.Deleted:
+                            return (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.DeletedBackgroundProperty);
+                        case ChangeType.Unchanged:
+                            return (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.UnchangedBackgroundProperty);
+                    }
+                }
+
+                return null;
+            }
+        }
+        public Brush SegmentForeground
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(TextChunk))
+                    return null;
+
+                SolidColorBrush brushColor = null;
+
+                if (Source is DiffViewer)
+                {
+                    switch (ChunkChange)
+                    {
+                        case ChangeType.Inserted:
+                            brushColor = (SolidColorBrush)Source.GetValue(DiffViewer.InsertedForegroundProperty);
+                            break;
+                        case ChangeType.Deleted:
+                            brushColor = (SolidColorBrush)Source.GetValue(DiffViewer.DeletedForegroundProperty);
+                            break;
+                        case ChangeType.Unchanged:
+                            brushColor = (SolidColorBrush)Source.GetValue(DiffViewer.UnchangedForegroundProperty);
+                            break;
+                        case ChangeType.Modified:
+                            brushColor = (SolidColorBrush)Source.GetValue(DiffViewer.ChangeTypeForegroundProperty);
+                            break;
+                    }
+                }
+                else if (Source is InlineDiffViewer)
+                {
+                    switch (ChunkChange)
+                    {
+                        case ChangeType.Inserted:
+                            brushColor = (SolidColorBrush)Source.GetValue(InlineDiffViewer.InsertedForegroundProperty);
+                            break;
+                        case ChangeType.Deleted:
+                            brushColor = (SolidColorBrush)Source.GetValue(InlineDiffViewer.DeletedForegroundProperty);
+                            break;
+                        case ChangeType.Unchanged:
+                            brushColor = (SolidColorBrush)Source.GetValue(InlineDiffViewer.UnchangedForegroundProperty);
+                            break;
+                        case ChangeType.Modified:
+                            brushColor = (SolidColorBrush)Source.GetValue(InlineDiffViewer.ChangeTypeForegroundProperty);
+                            break;
+                    }
+                }
+                else if (Source is SideBySideDiffViewer)
+                {
+                    switch (ChunkChange)
+                    {
+                        case ChangeType.Inserted:
+                            brushColor = (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.InsertedForegroundProperty);
+                            break;
+                        case ChangeType.Deleted:
+                            brushColor = (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.DeletedForegroundProperty);
+                            break;
+                        case ChangeType.Unchanged:
+                            brushColor = (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.UnchangedForegroundProperty);
+                            break;
+                        case ChangeType.Modified:
+                            brushColor = (SolidColorBrush)Source.GetValue(SideBySideDiffViewer.ChangeTypeForegroundProperty);
+                            break;
+                    }
+                }
+
+                return brushColor ?? FallbackForeground;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Can now easily handle 25k+ line files in side-by-side mode.

- Fully convert InternalLinesViewer to using virtualized component rendering
- Added a basic ViewModel for InternalLinesViewer (LineViewerLineData). Supports dynamic visibility changes.

You can increase the repetitions in `MainWindow.xaml.cs` to 1000 to get a 25k line document, which is handled on my system easily.

Let me know if there are any improvements you can offer. The style mechanism could be improved to be more pure-wpf, and I think the font properties might already inherit by default (although I'm not 100% sure about this one, I need to test it)