### PR TITLE
WPF: Add command bar for diff viewer

### DIFF
--- a/DiffPlex.App/DiffPlex.App.csproj
+++ b/DiffPlex.App/DiffPlex.App.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>DiffPlex.UI</RootNamespace>
     <AssemblyName>DiffPlex.App</AssemblyName>
@@ -43,8 +43,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.5" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.1" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/DiffPlex.Windows/DiffPlex.Windows.csproj
+++ b/DiffPlex.Windows/DiffPlex.Windows.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows10.0.17763.0;net6.0-windows10.0.19041.0;net6.0-windows10.0.22000.0</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows10.0.17763.0;net6.0-windows10.0.19041.0;net6.0-windows10.0.22000.0;net7.0-windows10.0.17763.0;net7.0-windows10.0.19041.0;net7.0-windows10.0.22000.0</TargetFrameworks>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>DiffPlex.UI</RootNamespace>
     <AssemblyName>DiffPlex.Windows</AssemblyName>
     <PackageId>DiffPlex.Windows</PackageId>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <PackageTags>diff</PackageTags>
     <PackageIcon>diffplex_icon.png</PackageIcon>
     <Description>DiffPlex.Windows is a Windows App SDK control library that allows you to programatically render visual text diffs in your application.</Description>
     <LangVersion>10.0</LangVersion>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1.0</FileVersion>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
     <Authors>Kingcean Tuan; Matthew Manela</Authors>
     <Copyright>Copyright (c) 2022 Matthew Manela. All rights reserved.</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -35,9 +35,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.5" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.1" />
-    <PackageReference Include="Trivial.WindowsKit" Version="6.5.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
+    <PackageReference Include="Trivial.WindowsKit" Version="7.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/DiffPlex.Wpf/Controls/DiffViewer.xaml
+++ b/DiffPlex.Wpf/Controls/DiffViewer.xaml
@@ -4,10 +4,69 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:DiffPlex.Wpf.Controls"
+             x:Name="SelfControl"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <Style x:Key="FocusVisual">
+            <Setter Property="Control.Template">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <Rectangle Margin="2" StrokeDashArray="1 2" SnapsToDevicePixels="true" StrokeThickness="1" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <SolidColorBrush x:Key="Button.Static.Background" Color="#33808080"/>
+        <SolidColorBrush x:Key="Button.Static.Border" Color="#44808080"/>
+        <SolidColorBrush x:Key="Button.MouseOver.Background" Color="#990099FF"/>
+        <SolidColorBrush x:Key="Button.MouseOver.Border" Color="#CC0099FF"/>
+        <SolidColorBrush x:Key="Button.Pressed.Background" Color="#EE0099FF"/>
+        <SolidColorBrush x:Key="Button.Pressed.Border" Color="#FF0099FF"/>
+        <SolidColorBrush x:Key="Button.Disabled.Background" Color="#99808080"/>
+        <SolidColorBrush x:Key="Button.Disabled.Border" Color="#CC808080"/>
+        <SolidColorBrush x:Key="Button.Disabled.Foreground" Color="#FF808080"/>
+        <Style x:Key="SolidButtonStyle" TargetType="{x:Type Button}">
+            <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
+            <Setter Property="Background" Value="{StaticResource Button.Static.Background}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource Button.Static.Border}"/>
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Padding" Value="1"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                        <Border x:Name="border" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" SnapsToDevicePixels="true">
+                            <ContentPresenter x:Name="contentPresenter" Focusable="False" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsDefaulted" Value="true">
+                                <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="true">
+                                <Setter Property="Background" TargetName="border" Value="{StaticResource Button.MouseOver.Background}"/>
+                                <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource Button.MouseOver.Border}"/>
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="true">
+                                <Setter Property="Background" TargetName="border" Value="{StaticResource Button.Pressed.Background}"/>
+                                <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource Button.Pressed.Border}"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="false">
+                                <Setter Property="Background" TargetName="border" Value="{StaticResource Button.Disabled.Background}"/>
+                                <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource Button.Disabled.Border}"/>
+                                <Setter Property="TextElement.Foreground" TargetName="contentPresenter" Value="{StaticResource Button.Disabled.Foreground}"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition x:Name="CommandRow" Height="0" />
             <RowDefinition x:Name="HeaderRow" Height="0"/>
             <RowDefinition x:Name="ContentRow" Height="*"/>
         </Grid.RowDefinitions>
@@ -15,7 +74,31 @@
             <ColumnDefinition x:Name="LeftColumn"/>
             <ColumnDefinition x:Name="RightColumn"/>
         </Grid.ColumnDefinitions>
-        <Border x:Name="HeaderBorder" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.ColumnSpan="2" >
+        <StackPanel x:Name="ActionBar" Background="#20808080" Orientation="Horizontal" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.ColumnSpan="2" >
+            <StackPanel x:Name="MenuPanel" Orientation="Horizontal" Margin="0" ></StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="16,0,16,0" >
+                <Button Style="{DynamicResource SolidButtonStyle}" Width="100" Height="20" x:Name="OpenFileButton" Content="Open File" Click="OpenFileButton_Click" Foreground="{Binding Foreground, ElementName=SelfControl}" Margin="0,0,16,0">
+                    <Button.ContextMenu>
+                        <ContextMenu x:Name="OpenFileContextMenu">
+                            <MenuItem x:Name="OpenLeftFileMenuItem" Header="Left" Click="OpenLeftFileMenuItem_Click" />
+                            <MenuItem x:Name="OpenRightFileMenuItem" Header="Right" Click="OpenRightFileMenuItem_Click" />
+                        </ContextMenu>
+                    </Button.ContextMenu>
+                </Button>
+                <Button Width="120" Height="20" x:Name="DiffButton" Content="Switch Mode" Click="DiffButton_Click" Foreground="{Binding Foreground, ElementName=SelfControl}" Margin="0" Style="{DynamicResource SolidButtonStyle}" />
+                <Button Width="20" Height="20" x:Name="FurtherActionsButton" Content="…" Click="FurtherActionsButton_Click" Foreground="{Binding Foreground, ElementName=SelfControl}" Margin="1,0,15,0" Style="{DynamicResource SolidButtonStyle}" />
+                <Label x:Name="GoToLabel" Height="20" Padding="0" Margin="16,0,8,0" VerticalContentAlignment="Center" Foreground="{Binding Foreground, ElementName=SelfControl}" >Go to</Label>
+                <TextBox Width="80" Height="20" VerticalContentAlignment="Center" x:Name="GoToText" Padding="8,0,8,0" Text="" Foreground="{Binding Foreground, ElementName=SelfControl}" CaretBrush="{Binding Foreground, ElementName=SelfControl}" Background="{x:Null}" Margin="0,0,8,0" TextChanged="GoToText_TextChanged" LostFocus="GoToText_LostFocus" />
+                <Button Width="20" Height="20" x:Name="NextButton" Click="NextButton_Click" Foreground="{Binding Foreground, ElementName=SelfControl}" Margin="0,0,1,0" Style="{DynamicResource SolidButtonStyle}" >
+                    <Path Width="10" Height="10" Stretch="Fill" Stroke="{Binding Foreground, ElementName=SelfControl}" Data="M0,1 L4,8 5,8 9,1" />
+                </Button>
+                <Button Width="20" Height="20" x:Name="PreviousButton" Click="PreviousButton_Click" Foreground="{Binding Foreground, ElementName=SelfControl}" Margin="0" Style="{DynamicResource SolidButtonStyle}" >
+                    <Path Width="10" Height="10" Stretch="Fill" Stroke="{Binding Foreground, ElementName=SelfControl}" Data="M0,8 L4,1 5,1 9,8" />
+                </Button>
+            </StackPanel>
+            <StackPanel x:Name="AdditionalMenuPanel" Orientation="Horizontal" Margin="0" ></StackPanel>
+        </StackPanel>
+        <Border x:Name="HeaderBorder" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Row="1" Grid.ColumnSpan="2" >
             <Border.ContextMenu>
                 <ContextMenu x:Name="HeaderContextMenu">
                     <MenuItem x:Name="InlineModeToggle" Header="_Unified view" Click="InlineModeToggle_Click" />
@@ -38,12 +121,12 @@
                 </ContextMenu>
             </Border.ContextMenu>
         </Border>
-        <TextBlock x:Name="InlineHeaderText" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.ColumnSpan="2" Visibility="Collapsed" />
-        <local:InternalLinesViewer x:Name="InlineContentPanel" Grid.ColumnSpan="2" Grid.Row="1" Visibility="Collapsed" />
-        <TextBlock x:Name="LeftHeaderText" HorizontalAlignment="Center" VerticalAlignment="Center" />
-        <local:InternalLinesViewer x:Name="LeftContentPanel" ScrollChanged="LeftContentPanel_ScrollChanged" Grid.Row="1" />
-        <GridSplitter x:Name="Splitter" Width="5" Grid.RowSpan="2" />
-        <TextBlock x:Name="RightHeaderText" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="1" />
-        <local:InternalLinesViewer x:Name="RightContentPanel" ScrollChanged="RightContentPanel_ScrollChanged" Grid.Row="1" Grid.Column="1" />
+        <TextBlock x:Name="InlineHeaderText" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="1" Grid.ColumnSpan="2" Visibility="Collapsed" />
+        <local:InternalLinesViewer x:Name="InlineContentPanel" Grid.ColumnSpan="2" Grid.Row="2" Visibility="Collapsed" />
+        <TextBlock x:Name="LeftHeaderText" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="1" />
+        <local:InternalLinesViewer x:Name="LeftContentPanel" ScrollChanged="LeftContentPanel_ScrollChanged" Grid.Row="2" />
+        <GridSplitter x:Name="Splitter" Width="5" Grid.Row="1" Grid.RowSpan="2" />
+        <TextBlock x:Name="RightHeaderText" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="1" Grid.Column="1" />
+        <local:InternalLinesViewer x:Name="RightContentPanel" ScrollChanged="RightContentPanel_ScrollChanged" Grid.Row="2" Grid.Column="1" />
     </Grid>
 </UserControl>

--- a/DiffPlex.Wpf/DiffPlex.Wpf.csproj
+++ b/DiffPlex.Wpf/DiffPlex.Wpf.csproj
@@ -4,13 +4,13 @@
     <TargetFrameworks>net6.0-windows;net46;net48</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>1.3.2</Version>
+    <Version>1.4.0</Version>
     <RootNamespace>DiffPlex.Wpf</RootNamespace>
     <AssemblyName>DiffPlex.Wpf</AssemblyName>
     <PackageTags>diff, wpf</PackageTags>
     <Description>DiffPlex.Wpf is a WPF control library that allows you to programatically render visual text diffs in your application. It also provide a diff viewer control used in Windows Forms application.</Description>
-    <AssemblyVersion>1.3.2.0</AssemblyVersion>
-    <FileVersion>1.3.2.0</FileVersion>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <FileVersion>1.4.0.0</FileVersion>
     <ApplicationIcon>..\DiffPlex.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>

--- a/DiffPlex.Wpf/DiffWindow.xaml
+++ b/DiffPlex.Wpf/DiffWindow.xaml
@@ -65,35 +65,5 @@
             </Setter>
         </Style>
     </Window.Resources>
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="30" />
-            <RowDefinition />
-        </Grid.RowDefinitions>
-        <StackPanel x:Name="ActionBar" Background="#20808080" Orientation="Horizontal" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" >
-            <StackPanel x:Name="MenuPanel" Orientation="Horizontal" Margin="0" ></StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="16,0,16,0" >
-                <Button Style="{DynamicResource SolidButtonStyle}" Width="100" Height="20" x:Name="OpenFileButton" Content="Open File" Click="OpenFileButton_Click" Foreground="{Binding Foreground, ElementName=MainWindow}" Margin="0,0,16,0">
-                    <Button.ContextMenu>
-                        <ContextMenu x:Name="OpenFileContextMenu">
-                            <MenuItem x:Name="OpenLeftFileMenuItem" Header="Left" Click="OpenLeftFileMenuItem_Click" />
-                            <MenuItem x:Name="OpenRightFileMenuItem" Header="Right" Click="OpenRightFileMenuItem_Click" />
-                        </ContextMenu>
-                    </Button.ContextMenu>
-                </Button>
-                <Button Width="120" Height="20" x:Name="DiffButton" Content="Switch Mode" Click="DiffButton_Click" Foreground="{Binding Foreground, ElementName=MainWindow}" Margin="0" Style="{DynamicResource SolidButtonStyle}" />
-                <Button Width="20" Height="20" x:Name="FurtherActionsButton" Content="…" Click="FurtherActionsButton_Click" Foreground="{Binding Foreground, ElementName=MainWindow}" Margin="1,0,15,0" Style="{DynamicResource SolidButtonStyle}" />
-                <Label x:Name="GoToLabel" Height="20" Padding="0" Margin="16,0,8,0" VerticalContentAlignment="Center" Foreground="{Binding Foreground, ElementName=MainWindow}" >Go to</Label>
-                <TextBox Width="80" Height="20" VerticalContentAlignment="Center" x:Name="GoToText" Padding="8,0,8,0" Text="" Foreground="{Binding Foreground, ElementName=MainWindow}" CaretBrush="{Binding Foreground, ElementName=MainWindow}" Background="{x:Null}" Margin="0,0,8,0" TextChanged="GoToText_TextChanged" LostFocus="GoToText_LostFocus" />
-                <Button Width="20" Height="20" x:Name="NextButton" Click="NextButton_Click" Foreground="{Binding Foreground, ElementName=MainWindow}" Margin="0,0,1,0" Style="{DynamicResource SolidButtonStyle}" >
-                    <Path Width="10" Height="10" Stretch="Fill" Stroke="{Binding Foreground, ElementName=MainWindow}" Data="M0,1 L4,8 5,8 9,1" />
-                </Button>
-                <Button Width="20" Height="20" x:Name="PreviousButton" Click="PreviousButton_Click" Foreground="{Binding Foreground, ElementName=MainWindow}" Margin="0" Style="{DynamicResource SolidButtonStyle}" >
-                    <Path Width="10" Height="10" Stretch="Fill" Stroke="{Binding Foreground, ElementName=MainWindow}" Data="M0,8 L4,1 5,1 9,8" />
-                </Button>
-            </StackPanel>
-            <StackPanel x:Name="AdditionalMenuPanel" Orientation="Horizontal" Margin="0" ></StackPanel>
-        </StackPanel>
-        <diffplex:DiffViewer x:Name="DiffView" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="0,0,0,0" Foreground="{Binding Foreground, ElementName=MainWindow}" Grid.Row="1"/>
-    </Grid>
+    <diffplex:DiffViewer x:Name="DiffView" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="0,0,0,0" Foreground="{Binding Foreground, ElementName=MainWindow}" IsCommandBarVisible="True" Grid.Row="1" />
 </Window>

--- a/NuGet.props
+++ b/NuGet.props
@@ -19,7 +19,7 @@
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
     <None Include="$(MSBuildThisFileDirectory)\images\diffplex_icon.png" Pack="true" PackagePath="diffplex_icon.png" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Bring the command bar from `DiffWindow` to `DiffViewer` (WPF).

```xaml
<diffplex:DiffViewer IsSideBySide="True" OldText="{Binding OldText}" NewText="{Binding NewText}" IsCommandBarVisible="True" />
```
![Screenshot](https://github.com/mmanela/diffplex/assets/1724940/8ac4c376-f199-4890-a8ca-96848f46708b)

The command bar is hidden by default. Property `IsCommandBarVisible` is the toggle to change the visibility. This commit also brings following methods to `DiffViewer`.

- `PreviousDiff`: scrolls to previous diff section.
- `NextDiff`: scrolls to next diff section.
- `OpenFileOnLeft`: opens file dialog to select a text file for old/left text.
- `OpenFileOnRight`: opens file dialog to select a text file for new/right text.

[NuGet packages](https://github.com/mmanela/diffplex/files/11686719/DiffPlex.Wpf.1.4.0.zip) | #106