### PR TITLE
Move to IReadOnlyList

### DIFF
--- a/DiffPlex/Chunkers/CharacterChunker.cs
+++ b/DiffPlex/Chunkers/CharacterChunker.cs
@@ -1,4 +1,6 @@
-﻿namespace DiffPlex.Chunkers
+﻿using System.Collections.Generic;
+
+namespace DiffPlex.Chunkers
 {
     public class CharacterChunker:IChunker
     {
@@ -7,7 +9,7 @@
         /// </summary>
         public static CharacterChunker Instance { get; } = new CharacterChunker();
 
-        public string[] Chunk(string text)
+        public IReadOnlyList<string> Chunk(string text)
         {
             var s = new string[text.Length];
             for (int i = 0; i < text.Length; i++) s[i] = text[i].ToString();

--- a/DiffPlex/Chunkers/CustomFunctionChunker.cs
+++ b/DiffPlex/Chunkers/CustomFunctionChunker.cs
@@ -1,18 +1,19 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace DiffPlex.Chunkers
 {
     public class CustomFunctionChunker: IChunker
     {
-        private readonly Func<string, string[]> customChunkerFunc;
+        private readonly Func<string, IReadOnlyList<string>> customChunkerFunc;
 
-        public CustomFunctionChunker(Func<string, string[]> customChunkerFunc)
+        public CustomFunctionChunker(Func<string, IReadOnlyList<string>> customChunkerFunc)
         {
             if (customChunkerFunc == null) throw new ArgumentNullException(nameof(customChunkerFunc));
             this.customChunkerFunc = customChunkerFunc;
         }
 
-        public string[] Chunk(string text)
+        public IReadOnlyList<string> Chunk(string text)
         {
             return customChunkerFunc(text);
         }

--- a/DiffPlex/Chunkers/DelimiterChunker.cs
+++ b/DiffPlex/Chunkers/DelimiterChunker.cs
@@ -17,7 +17,7 @@ namespace DiffPlex.Chunkers
             this.delimiters = delimiters;
         }
 
-        public string[] Chunk(string str)
+        public IReadOnlyList<string> Chunk(string str)
         {
             var list = new List<string>();
             int begin = 0;
@@ -76,7 +76,7 @@ namespace DiffPlex.Chunkers
                 }
             }
 
-            return list.ToArray();
+            return list;
         }
     }
 }

--- a/DiffPlex/Chunkers/LineChunker.cs
+++ b/DiffPlex/Chunkers/LineChunker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace DiffPlex.Chunkers
 {
@@ -11,7 +12,7 @@ namespace DiffPlex.Chunkers
         /// </summary>
         public static LineChunker Instance { get; } = new LineChunker();
 
-        public string[] Chunk(string text)
+        public IReadOnlyList<string> Chunk(string text)
         {
             return text.Split(lineSeparators, StringSplitOptions.None);
         }

--- a/DiffPlex/Chunkers/LineEndingsPreservingChunker.cs
+++ b/DiffPlex/Chunkers/LineEndingsPreservingChunker.cs
@@ -11,7 +11,7 @@ namespace DiffPlex.Chunkers
         /// </summary>
         public static LineEndingsPreservingChunker Instance { get; } = new LineEndingsPreservingChunker();
 
-        public string[] Chunk(string text)
+        public IReadOnlyList<string> Chunk(string text)
         {
             if (string.IsNullOrEmpty(text))
                 return emptyArray;
@@ -45,7 +45,7 @@ namespace DiffPlex.Chunkers
                 output.Add(str);
             }
 
-            return output.ToArray();
+            return output;
         }
     }
 }

--- a/DiffPlex/DiffBuilder/InlineDiffBuilder.cs
+++ b/DiffPlex/DiffBuilder/InlineDiffBuilder.cs
@@ -112,7 +112,7 @@ namespace DiffPlex.DiffBuilder
                 }
             }
 
-            for (; bPos < diffResult.PiecesNew.Length; bPos++)
+            for (; bPos < diffResult.PiecesNew.Count; bPos++)
                 pieces.Add(new DiffPiece(diffResult.PiecesNew[bPos], ChangeType.Unchanged, bPos + 1));
         }
     }

--- a/DiffPlex/DiffBuilder/SideBySideDiffBuilder.cs
+++ b/DiffPlex/DiffBuilder/SideBySideDiffBuilder.cs
@@ -180,7 +180,7 @@ namespace DiffPlex.DiffBuilder
                 }
             }
 
-            while (bPos < diffResult.PiecesNew.Length && aPos < diffResult.PiecesOld.Length)
+            while (bPos < diffResult.PiecesNew.Count && aPos < diffResult.PiecesOld.Count)
             {
                 oldPieces.Add(new DiffPiece(diffResult.PiecesOld[aPos], ChangeType.Unchanged, aPos + 1));
                 newPieces.Add(new DiffPiece(diffResult.PiecesNew[bPos], ChangeType.Unchanged, bPos + 1));

--- a/DiffPlex/DiffPlex.csproj
+++ b/DiffPlex/DiffPlex.csproj
@@ -9,8 +9,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Condition="'$(TargetFramework)' == 'net40'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
-    <PackageReference Condition="'$(TargetFramework)' == 'net35'" Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" PrivateAssets="all" />
     <None Include="..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 </Project>

--- a/DiffPlex/DiffPlex.csproj
+++ b/DiffPlex/DiffPlex.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NuGet.props" />
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;netstandard1.0;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.0;netstandard2.0;net6.0</TargetFrameworks>
     <Version>1.7.2</Version>
     <PackageTags>diff</PackageTags>
     <Description>DiffPlex is a diffing library that allows you to programmatically create text diffs. DiffPlex is a fast and tested library.</Description>

--- a/DiffPlex/Differ.cs
+++ b/DiffPlex/Differ.cs
@@ -333,10 +333,10 @@ namespace DiffPlex
                 : chunker.Chunk(data.RawData);
 
             data.Pieces = pieces;
-            data.HashedPieces = new int[pieces.Length];
-            data.Modifications = new bool[pieces.Length];
+            data.HashedPieces = new int[pieces.Count];
+            data.Modifications = new bool[pieces.Count];
 
-            for (int i = 0; i < pieces.Length; i++)
+            for (int i = 0; i < pieces.Count; i++)
             {
                 string piece = pieces[i];
                 if (ignoreWhitespace) piece = piece.Trim();

--- a/DiffPlex/IChunker.cs
+++ b/DiffPlex/IChunker.cs
@@ -1,4 +1,6 @@
-﻿namespace DiffPlex
+﻿using System.Collections.Generic;
+
+namespace DiffPlex
 {
     /// <summary>
     /// Responsible for how to turn the document into pieces
@@ -8,6 +10,6 @@
         /// <summary>
         /// Divide text into sub-parts
         /// </summary>
-        string[] Chunk(string text);
+        IReadOnlyList<string> Chunk(string text);
     }
 }

--- a/DiffPlex/Model/DiffResult.cs
+++ b/DiffPlex/Model/DiffResult.cs
@@ -10,12 +10,12 @@ namespace DiffPlex.Model
         /// <summary>
         /// The chunked pieces of the old text
         /// </summary>
-        public string[] PiecesOld { get; }
+        public IReadOnlyList<string> PiecesOld { get; }
 
         /// <summary>
         /// The chunked pieces of the new text
         /// </summary>
-        public string[] PiecesNew { get; }
+        public IReadOnlyList<string> PiecesNew { get; }
 
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace DiffPlex.Model
         /// </summary>
         public IList<DiffBlock> DiffBlocks { get; }
 
-        public DiffResult(string[] piecesOld, string[] piecesNew, IList<DiffBlock> blocks)
+        public DiffResult(IReadOnlyList<string> piecesOld, IReadOnlyList<string> piecesNew, IList<DiffBlock> blocks)
         {
             PiecesOld = piecesOld;
             PiecesNew = piecesNew;

--- a/DiffPlex/Model/ModificationData.cs
+++ b/DiffPlex/Model/ModificationData.cs
@@ -1,4 +1,6 @@
-﻿namespace DiffPlex.Model
+﻿using System.Collections.Generic;
+
+namespace DiffPlex.Model
 {
     public class ModificationData
     {
@@ -8,7 +10,7 @@
 
         public bool[] Modifications { get; set; }
 
-        public string[] Pieces { get; set; }
+        public IReadOnlyList<string> Pieces { get; set; }
 
         public ModificationData(string str)
         {

--- a/Facts.DiffPlex/Chunkers/LineEndingsPreservingChunkerFacts.cs
+++ b/Facts.DiffPlex/Chunkers/LineEndingsPreservingChunkerFacts.cs
@@ -16,7 +16,7 @@ namespace Facts.DiffPlex.Chunkers
             var chunks = chunker.Chunk(sampleText);
 
             //ASSERT
-            Assert.Equal(4, chunks.Length);
+            Assert.Equal(4, chunks.Count);
             Assert.Equal("\r\n", chunks[0]);
             Assert.Equal("First\r\n", chunks[1]);
             Assert.Equal("Second\r\n", chunks[2]);
@@ -34,7 +34,7 @@ namespace Facts.DiffPlex.Chunkers
             var chunks = chunker.Chunk(sampleText);
 
             //ASSERT
-            Assert.Equal(3, chunks.Length);
+            Assert.Equal(3, chunks.Count);
             Assert.Equal("First\r\n", chunks[0]);
             Assert.Equal("Second\r\n", chunks[1]);
             Assert.Equal("Last", chunks[2]);
@@ -51,7 +51,7 @@ namespace Facts.DiffPlex.Chunkers
             var chunks = chunker.Chunk(sampleText);
 
             //ASSERT
-            Assert.Equal(3, chunks.Length);
+            Assert.Equal(3, chunks.Count);
             Assert.Equal("\r\n", chunks[0]);
             Assert.Equal("\r\n", chunks[1]);
             Assert.Equal("\r\n", chunks[2]);
@@ -68,7 +68,7 @@ namespace Facts.DiffPlex.Chunkers
             var chunks = chunker.Chunk(sampleText);
 
             //ASSERT
-            Assert.Equal(4, chunks.Length);
+            Assert.Equal(4, chunks.Count);
             Assert.Equal("\r\n", chunks[0]);
             Assert.Equal("First\n", chunks[1]);
             Assert.Equal("Second\r", chunks[2]);


### PR DESCRIPTION
avoid the array copy allocation of .ToArray()

drops net35 and net40. moves to net45