### PR TITLE
Allow text wrapping in WPF controls

### DIFF
--- a/DiffPlex.Wpf.Demo/MainWindow.xaml
+++ b/DiffPlex.Wpf.Demo/MainWindow.xaml
@@ -18,6 +18,7 @@
         <StackPanel Orientation="Horizontal" Grid.Row="1" Background="#20808080">
             <Button Width="100" Height="20" x:Name="DiffButton" Content="Switch Mode" Click="DiffButton_Click" BorderBrush="{x:Null}" BorderThickness="0" Margin="16,0,1,0" />
             <Button Width="20" Height="20" x:Name="FutherActionsButton" Content="…" Click="FutherActionsButton_Click" BorderBrush="{x:Null}" BorderThickness="0" Margin="0,0,31,0" />
+            <Button Width="100" Height="20" x:Name="TextWrapButton" Content="WrapText" Click="TextWrapButton_Click" BorderBrush="{x:Null}" Background="Green" BorderThickness="0" Margin="16,0,1,0" />
             <CheckBox Width="120" Height="20" VerticalContentAlignment="Center" IsChecked="{Binding IsSideBySide, ElementName=DiffView}" Content="Is_SideBySide" Foreground="{Binding Foreground, ElementName=DiffView}" />
             <CheckBox Height="20" VerticalContentAlignment="Center" x:Name="IgnoreUnchangedCheckBox" IsChecked="{Binding IgnoreUnchanged, ElementName=DiffView}" Content="IgnoreUnchanged" Margin="0,0,24,0" Foreground="{Binding Foreground, ElementName=DiffView}" />
             <Label Height="20" VerticalContentAlignment="Center" Padding="0,0,8,0" x:Name="MarginLineCountLabel" Target="{Binding ElementName=MarginLineCount}" Foreground="{Binding Foreground, ElementName=DiffView}">LinesContext</Label>

--- a/DiffPlex.Wpf.Demo/MainWindow.xaml.cs
+++ b/DiffPlex.Wpf.Demo/MainWindow.xaml.cs
@@ -59,6 +59,11 @@ public partial class MainWindow : Window
         DiffView.ShowInline();
     }
 
+    private void TextWrapButton_Click(object sender, RoutedEventArgs e)
+    {
+        DiffView.EnableTextWrapping();
+    }
+
     private void FutherActionsButton_Click(object sender, RoutedEventArgs e)
     {
         DiffView.OpenViewModeContextMenu();

--- a/DiffPlex.Wpf/Controls/BooleanToScrollBarVisibilityConverter.cs
+++ b/DiffPlex.Wpf/Controls/BooleanToScrollBarVisibilityConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace DiffPlex.Wpf.Controls
+{
+    public class BooleanToScrollBarVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool isTextWrapEnabled)
+            {
+                return isTextWrapEnabled ? ScrollBarVisibility.Hidden : ScrollBarVisibility.Auto;
+            }
+            return ScrollBarVisibility.Auto;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/DiffPlex.Wpf/Controls/DiffViewer.xaml
+++ b/DiffPlex.Wpf/Controls/DiffViewer.xaml
@@ -1,62 +1,81 @@
-﻿<UserControl x:Class="DiffPlex.Wpf.Controls.DiffViewer"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:DiffPlex.Wpf.Controls"
-             x:Name="SelfControl"
-             mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
+﻿<UserControl
+    x:Class="DiffPlex.Wpf.Controls.DiffViewer"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:DiffPlex.Wpf.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    x:Name="SelfControl"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    mc:Ignorable="d">
     <UserControl.Resources>
         <Style x:Key="FocusVisual">
             <Setter Property="Control.Template">
                 <Setter.Value>
                     <ControlTemplate>
-                        <Rectangle Margin="2" StrokeDashArray="1 2" SnapsToDevicePixels="true" StrokeThickness="1" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+                        <Rectangle
+                            Margin="2"
+                            SnapsToDevicePixels="true"
+                            Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                            StrokeDashArray="1 2"
+                            StrokeThickness="1" />
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
         </Style>
-        <SolidColorBrush x:Key="Button.Static.Background" Color="#33808080"/>
-        <SolidColorBrush x:Key="Button.Static.Border" Color="#44808080"/>
-        <SolidColorBrush x:Key="Button.MouseOver.Background" Color="#990099FF"/>
-        <SolidColorBrush x:Key="Button.MouseOver.Border" Color="#CC0099FF"/>
-        <SolidColorBrush x:Key="Button.Pressed.Background" Color="#EE0099FF"/>
-        <SolidColorBrush x:Key="Button.Pressed.Border" Color="#FF0099FF"/>
-        <SolidColorBrush x:Key="Button.Disabled.Background" Color="#99808080"/>
-        <SolidColorBrush x:Key="Button.Disabled.Border" Color="#CC808080"/>
-        <SolidColorBrush x:Key="Button.Disabled.Foreground" Color="#FF808080"/>
+        <SolidColorBrush x:Key="Button.Static.Background" Color="#33808080" />
+        <SolidColorBrush x:Key="Button.Static.Border" Color="#44808080" />
+        <SolidColorBrush x:Key="Button.MouseOver.Background" Color="#990099FF" />
+        <SolidColorBrush x:Key="Button.MouseOver.Border" Color="#CC0099FF" />
+        <SolidColorBrush x:Key="Button.Pressed.Background" Color="#EE0099FF" />
+        <SolidColorBrush x:Key="Button.Pressed.Border" Color="#FF0099FF" />
+        <SolidColorBrush x:Key="Button.Disabled.Background" Color="#99808080" />
+        <SolidColorBrush x:Key="Button.Disabled.Border" Color="#CC808080" />
+        <SolidColorBrush x:Key="Button.Disabled.Foreground" Color="#FF808080" />
         <Style x:Key="SolidButtonStyle" TargetType="{x:Type Button}">
-            <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
-            <Setter Property="Background" Value="{StaticResource Button.Static.Background}"/>
-            <Setter Property="BorderBrush" Value="{StaticResource Button.Static.Border}"/>
-            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="HorizontalContentAlignment" Value="Center"/>
-            <Setter Property="VerticalContentAlignment" Value="Center"/>
-            <Setter Property="Padding" Value="1"/>
+            <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}" />
+            <Setter Property="Background" Value="{StaticResource Button.Static.Background}" />
+            <Setter Property="BorderBrush" Value="{StaticResource Button.Static.Border}" />
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Padding" Value="1" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type Button}">
-                        <Border x:Name="border" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" SnapsToDevicePixels="true">
-                            <ContentPresenter x:Name="contentPresenter" Focusable="False" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                        <Border
+                            x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            SnapsToDevicePixels="true">
+                            <ContentPresenter
+                                x:Name="contentPresenter"
+                                Margin="{TemplateBinding Padding}"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Focusable="False"
+                                RecognizesAccessKey="True"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsDefaulted" Value="true">
-                                <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+                                <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
                             </Trigger>
                             <Trigger Property="IsMouseOver" Value="true">
-                                <Setter Property="Background" TargetName="border" Value="{StaticResource Button.MouseOver.Background}"/>
-                                <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource Button.MouseOver.Border}"/>
+                                <Setter TargetName="border" Property="Background" Value="{StaticResource Button.MouseOver.Background}" />
+                                <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource Button.MouseOver.Border}" />
                             </Trigger>
                             <Trigger Property="IsPressed" Value="true">
-                                <Setter Property="Background" TargetName="border" Value="{StaticResource Button.Pressed.Background}"/>
-                                <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource Button.Pressed.Border}"/>
+                                <Setter TargetName="border" Property="Background" Value="{StaticResource Button.Pressed.Background}" />
+                                <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource Button.Pressed.Border}" />
                             </Trigger>
                             <Trigger Property="IsEnabled" Value="false">
-                                <Setter Property="Background" TargetName="border" Value="{StaticResource Button.Disabled.Background}"/>
-                                <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource Button.Disabled.Border}"/>
-                                <Setter Property="TextElement.Foreground" TargetName="contentPresenter" Value="{StaticResource Button.Disabled.Foreground}"/>
+                                <Setter TargetName="border" Property="Background" Value="{StaticResource Button.Disabled.Background}" />
+                                <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource Button.Disabled.Border}" />
+                                <Setter TargetName="contentPresenter" Property="TextElement.Foreground" Value="{StaticResource Button.Disabled.Foreground}" />
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
@@ -67,66 +86,204 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition x:Name="CommandRow" Height="0" />
-            <RowDefinition x:Name="HeaderRow" Height="0"/>
-            <RowDefinition x:Name="ContentRow" Height="*"/>
+            <RowDefinition x:Name="HeaderRow" Height="0" />
+            <RowDefinition x:Name="ContentRow" Height="*" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition x:Name="LeftColumn"/>
-            <ColumnDefinition x:Name="RightColumn"/>
+            <ColumnDefinition x:Name="LeftColumn" />
+            <ColumnDefinition x:Name="RightColumn" />
         </Grid.ColumnDefinitions>
-        <StackPanel x:Name="ActionBar" Background="#20808080" Orientation="Horizontal" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.ColumnSpan="2" >
-            <StackPanel x:Name="MenuPanel" Orientation="Horizontal" Margin="0" ></StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="16,0,16,0" >
-                <Button Style="{DynamicResource SolidButtonStyle}" Width="100" Height="20" x:Name="OpenFileButton" Content="Open File" Click="OpenFileButton_Click" Foreground="{Binding Foreground, ElementName=SelfControl}" Margin="0,0,16,0">
+        <StackPanel
+            x:Name="ActionBar"
+            Grid.ColumnSpan="2"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            Background="#20808080"
+            Orientation="Horizontal">
+            <StackPanel
+                x:Name="MenuPanel"
+                Margin="0"
+                Orientation="Horizontal" />
+            <StackPanel Margin="16,0,16,0" Orientation="Horizontal">
+                <Button
+                    x:Name="OpenFileButton"
+                    Width="100"
+                    Height="20"
+                    Margin="0,0,16,0"
+                    Click="OpenFileButton_Click"
+                    Content="Open File"
+                    Foreground="{Binding Foreground, ElementName=SelfControl}"
+                    Style="{DynamicResource SolidButtonStyle}">
                     <Button.ContextMenu>
                         <ContextMenu x:Name="OpenFileContextMenu">
-                            <MenuItem x:Name="OpenLeftFileMenuItem" Header="Left" Click="OpenLeftFileMenuItem_Click" />
-                            <MenuItem x:Name="OpenRightFileMenuItem" Header="Right" Click="OpenRightFileMenuItem_Click" />
+                            <MenuItem
+                                x:Name="OpenLeftFileMenuItem"
+                                Click="OpenLeftFileMenuItem_Click"
+                                Header="Left" />
+                            <MenuItem
+                                x:Name="OpenRightFileMenuItem"
+                                Click="OpenRightFileMenuItem_Click"
+                                Header="Right" />
                         </ContextMenu>
                     </Button.ContextMenu>
                 </Button>
-                <Button Width="120" Height="20" x:Name="DiffButton" Content="Switch Mode" Click="DiffButton_Click" Foreground="{Binding Foreground, ElementName=SelfControl}" Margin="0" Style="{DynamicResource SolidButtonStyle}" />
-                <Button Width="20" Height="20" x:Name="FurtherActionsButton" Content="…" Click="FurtherActionsButton_Click" Foreground="{Binding Foreground, ElementName=SelfControl}" Margin="1,0,15,0" Style="{DynamicResource SolidButtonStyle}" />
-                <Label x:Name="GoToLabel" Height="20" Padding="0" Margin="16,0,8,0" VerticalContentAlignment="Center" Foreground="{Binding Foreground, ElementName=SelfControl}" >Go to</Label>
-                <TextBox Width="80" Height="20" VerticalContentAlignment="Center" x:Name="GoToText" Padding="8,0,8,0" Text="" Foreground="{Binding Foreground, ElementName=SelfControl}" CaretBrush="{Binding Foreground, ElementName=SelfControl}" Background="{x:Null}" Margin="0,0,8,0" TextChanged="GoToText_TextChanged" LostFocus="GoToText_LostFocus" />
-                <Button Width="20" Height="20" x:Name="NextButton" Click="NextButton_Click" Foreground="{Binding Foreground, ElementName=SelfControl}" Margin="0,0,1,0" Style="{DynamicResource SolidButtonStyle}" >
-                    <Path Width="10" Height="10" Stretch="Fill" Stroke="{Binding Foreground, ElementName=SelfControl}" Data="M0,1 L4,8 5,8 9,1" />
+                <Button
+                    x:Name="DiffButton"
+                    Width="120"
+                    Height="20"
+                    Margin="0"
+                    Click="DiffButton_Click"
+                    Content="Switch Mode"
+                    Foreground="{Binding Foreground, ElementName=SelfControl}"
+                    Style="{DynamicResource SolidButtonStyle}" />
+                <Button
+                    x:Name="FurtherActionsButton"
+                    Width="20"
+                    Height="20"
+                    Margin="1,0,15,0"
+                    Click="FurtherActionsButton_Click"
+                    Content="…"
+                    Foreground="{Binding Foreground, ElementName=SelfControl}"
+                    Style="{DynamicResource SolidButtonStyle}" />
+                <Label
+                    x:Name="GoToLabel"
+                    Height="20"
+                    Margin="16,0,8,0"
+                    Padding="0"
+                    VerticalContentAlignment="Center"
+                    Foreground="{Binding Foreground, ElementName=SelfControl}">
+                    Go to
+                </Label>
+                <TextBox
+                    x:Name="GoToText"
+                    Width="80"
+                    Height="20"
+                    Margin="0,0,8,0"
+                    Padding="8,0,8,0"
+                    VerticalContentAlignment="Center"
+                    Background="{x:Null}"
+                    CaretBrush="{Binding Foreground, ElementName=SelfControl}"
+                    Foreground="{Binding Foreground, ElementName=SelfControl}"
+                    LostFocus="GoToText_LostFocus"
+                    Text=""
+                    TextChanged="GoToText_TextChanged" />
+                <Button
+                    x:Name="NextButton"
+                    Width="20"
+                    Height="20"
+                    Margin="0,0,1,0"
+                    Click="NextButton_Click"
+                    Foreground="{Binding Foreground, ElementName=SelfControl}"
+                    Style="{DynamicResource SolidButtonStyle}">
+                    <Path
+                        Width="10"
+                        Height="10"
+                        Data="M0,1 L4,8 5,8 9,1"
+                        Stretch="Fill"
+                        Stroke="{Binding Foreground, ElementName=SelfControl}" />
                 </Button>
-                <Button Width="20" Height="20" x:Name="PreviousButton" Click="PreviousButton_Click" Foreground="{Binding Foreground, ElementName=SelfControl}" Margin="0" Style="{DynamicResource SolidButtonStyle}" >
-                    <Path Width="10" Height="10" Stretch="Fill" Stroke="{Binding Foreground, ElementName=SelfControl}" Data="M0,8 L4,1 5,1 9,8" />
+                <Button
+                    x:Name="PreviousButton"
+                    Width="20"
+                    Height="20"
+                    Margin="0"
+                    Click="PreviousButton_Click"
+                    Foreground="{Binding Foreground, ElementName=SelfControl}"
+                    Style="{DynamicResource SolidButtonStyle}">
+                    <Path
+                        Width="10"
+                        Height="10"
+                        Data="M0,8 L4,1 5,1 9,8"
+                        Stretch="Fill"
+                        Stroke="{Binding Foreground, ElementName=SelfControl}" />
                 </Button>
             </StackPanel>
-            <StackPanel x:Name="AdditionalMenuPanel" Orientation="Horizontal" Margin="0" ></StackPanel>
+            <StackPanel
+                x:Name="AdditionalMenuPanel"
+                Margin="0"
+                Orientation="Horizontal" />
         </StackPanel>
-        <Border x:Name="HeaderBorder" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Row="1" Grid.ColumnSpan="2" >
+        <Border
+            x:Name="HeaderBorder"
+            Grid.Row="1"
+            Grid.ColumnSpan="2"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch">
             <Border.ContextMenu>
                 <ContextMenu x:Name="HeaderContextMenu">
-                    <MenuItem x:Name="InlineModeToggle" Header="_Unified view" Click="InlineModeToggle_Click" />
-                    <MenuItem x:Name="SideBySideModeToggle" Header="_Split view" Click="SideBySideModeToggle_Click" IsChecked="True" />
+                    <MenuItem
+                        x:Name="InlineModeToggle"
+                        Click="InlineModeToggle_Click"
+                        Header="_Unified view" />
+                    <MenuItem
+                        x:Name="SideBySideModeToggle"
+                        Click="SideBySideModeToggle_Click"
+                        Header="_Split view"
+                        IsChecked="True" />
                     <Separator />
-                    <MenuItem x:Name="CollapseUnchangedSectionsToggle" Header="_Collapse unchanged sections" Click="CollapseUnchangedSectionsToggle_Click" />
-                    <MenuItem x:Name="ContextLinesMenuItems" Header="_Lines for context" Visibility="Collapsed">
-                        <MenuItem Header="_0" Click="ContextLineMenuItem_Click" />
-                        <MenuItem Header="_1" Click="ContextLineMenuItem_Click" />
-                        <MenuItem Header="_2" Click="ContextLineMenuItem_Click" />
-                        <MenuItem Header="_3" Click="ContextLineMenuItem_Click" />
-                        <MenuItem Header="_4" Click="ContextLineMenuItem_Click" />
-                        <MenuItem Header="_5" Click="ContextLineMenuItem_Click" />
-                        <MenuItem Header="_6" Click="ContextLineMenuItem_Click" />
-                        <MenuItem Header="_7" Click="ContextLineMenuItem_Click" />
-                        <MenuItem Header="_8" Click="ContextLineMenuItem_Click" />
-                        <MenuItem Header="_9" Click="ContextLineMenuItem_Click" />
-                        <MenuItem x:Name="CustomizedContextLineMenuItem" Header="_X" Click="ContextLineMenuItem_Click" Visibility="Collapsed" />
+                    <MenuItem
+                        x:Name="CollapseUnchangedSectionsToggle"
+                        Click="CollapseUnchangedSectionsToggle_Click"
+                        Header="_Collapse unchanged sections" />
+                    <MenuItem
+                        x:Name="ContextLinesMenuItems"
+                        Header="_Lines for context"
+                        Visibility="Collapsed">
+                        <MenuItem Click="ContextLineMenuItem_Click" Header="_0" />
+                        <MenuItem Click="ContextLineMenuItem_Click" Header="_1" />
+                        <MenuItem Click="ContextLineMenuItem_Click" Header="_2" />
+                        <MenuItem Click="ContextLineMenuItem_Click" Header="_3" />
+                        <MenuItem Click="ContextLineMenuItem_Click" Header="_4" />
+                        <MenuItem Click="ContextLineMenuItem_Click" Header="_5" />
+                        <MenuItem Click="ContextLineMenuItem_Click" Header="_6" />
+                        <MenuItem Click="ContextLineMenuItem_Click" Header="_7" />
+                        <MenuItem Click="ContextLineMenuItem_Click" Header="_8" />
+                        <MenuItem Click="ContextLineMenuItem_Click" Header="_9" />
+                        <MenuItem
+                            x:Name="CustomizedContextLineMenuItem"
+                            Click="ContextLineMenuItem_Click"
+                            Header="_X"
+                            Visibility="Collapsed" />
                     </MenuItem>
                 </ContextMenu>
             </Border.ContextMenu>
         </Border>
-        <TextBlock x:Name="InlineHeaderText" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="1" Grid.ColumnSpan="2" Visibility="Collapsed" />
-        <local:InternalLinesViewer x:Name="InlineContentPanel" Grid.ColumnSpan="2" Grid.Row="2" Visibility="Collapsed" />
-        <TextBlock x:Name="LeftHeaderText" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="1" />
-        <local:InternalLinesViewer x:Name="LeftContentPanel" ScrollChanged="LeftContentPanel_ScrollChanged" Grid.Row="2" />
-        <GridSplitter x:Name="Splitter" Width="5" Grid.Row="1" Grid.RowSpan="2" />
-        <TextBlock x:Name="RightHeaderText" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="1" Grid.Column="1" />
-        <local:InternalLinesViewer x:Name="RightContentPanel" ScrollChanged="RightContentPanel_ScrollChanged" Grid.Row="2" Grid.Column="1" />
+        <TextBlock
+            x:Name="InlineHeaderText"
+            Grid.Row="1"
+            Grid.ColumnSpan="2"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Visibility="Collapsed" />
+        <local:InternalLinesViewer
+            x:Name="InlineContentPanel"
+            Grid.Row="2"
+            Grid.ColumnSpan="2"
+            Visibility="Collapsed" />
+        <TextBlock
+            x:Name="LeftHeaderText"
+            Grid.Row="1"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center" />
+        <local:InternalLinesViewer
+            x:Name="LeftContentPanel"
+            Grid.Row="2"
+            ScrollChanged="LeftContentPanel_ScrollChanged" />
+        <GridSplitter
+            x:Name="Splitter"
+            Grid.Row="1"
+            Grid.RowSpan="2"
+            Width="5" />
+        <TextBlock
+            x:Name="RightHeaderText"
+            Grid.Row="1"
+            Grid.Column="1"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center" />
+        <local:InternalLinesViewer
+            x:Name="RightContentPanel"
+            Grid.Row="2"
+            Grid.Column="1"
+            ScrollChanged="RightContentPanel_ScrollChanged" />
     </Grid>
 </UserControl>

--- a/DiffPlex.Wpf/Controls/DiffViewer.xaml.cs
+++ b/DiffPlex.Wpf/Controls/DiffViewer.xaml.cs
@@ -81,6 +81,11 @@ public partial class DiffViewer : UserControl
     public static readonly DependencyProperty LineNumberForegroundProperty = RegisterDependencyProperty<Brush>(nameof(LineNumberForeground), new SolidColorBrush(Color.FromArgb(255, 64, 128, 160)));
 
     /// <summary>
+    /// The property of text wrapping state.
+    /// </summary>
+    public static readonly DependencyProperty IsTextWrapEnabledProperty = RegisterRefreshDependencyProperty(nameof(IsTextWrapEnabled), false);
+
+    /// <summary>
     /// The property of line number width.
     /// </summary>
     public static readonly DependencyProperty LineNumberWidthProperty = RegisterDependencyProperty(nameof(LineNumberWidth), 60, (d, e) =>
@@ -652,6 +657,17 @@ public partial class DiffViewer : UserControl
     }
 
     /// <summary>
+    /// Gets or sets the value indicating whether is wrap text.
+    /// </summary>
+    [Bindable(true)]
+    [Category("Appearance")]
+    public bool IsTextWrapEnabled
+    {
+        get => (bool)GetValue(IsTextWrapEnabledProperty);
+        set => SetValue(IsTextWrapEnabledProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the display name of inline mode toggle.
     /// </summary>
     [Category("Appearance")]
@@ -1142,7 +1158,7 @@ public partial class DiffViewer : UserControl
         var m = sideBySideResult;
         CollapseUnchangedSectionsToggle.IsChecked = IgnoreUnchanged;
         if (m == null) return;
-        var contextLineCount = IgnoreUnchanged ? LinesContext: -1;
+        var contextLineCount = IgnoreUnchanged ? LinesContext : -1;
         Helper.InsertLines(LeftContentPanel, m.OldText?.Lines, true, this, contextLineCount);
         Helper.InsertLines(RightContentPanel, m.NewText.Lines, false, this, contextLineCount);
     }
@@ -1304,6 +1320,12 @@ public partial class DiffViewer : UserControl
         var line = GetLinesAfterViewport(isLeft, VisibilityLevels.All).FirstOrDefault(ele => ele.Type != ChangeType.Unchanged);
         GoTo(line, isLeft);
         return line;
+    }
+
+    public void EnableTextWrapping()
+    {
+        IsTextWrapEnabled = true;
+        this.Refresh();
     }
 
     private string GenerateHeader(FileInfo file)

--- a/DiffPlex.Wpf/Controls/Helper.cs
+++ b/DiffPlex.Wpf/Controls/Helper.cs
@@ -41,6 +41,8 @@ internal static class Helper
     internal static void RenderInlineDiffs(InternalLinesViewer viewer, ICollection<DiffPiece> lines, UIElement source, int contextLineCount)
     {
         viewer.Clear();
+        var diffViewer = source as DiffViewer;
+
         if (lines == null) return;
         if (lines.Any() == false) return;
         var disableSubPieces = lines.Count > MaxCount;    // For performance.
@@ -48,8 +50,17 @@ internal static class Helper
         {
             if (line == null)
             {
-                var c = viewer.Add(null, null, null as string, ChangeType.Unchanged.ToString(), source);
-                c.Tag = line;
+                if (diffViewer.IsTextWrapEnabled)
+                {
+                    var c = viewer.Add(null, null, null as string, ChangeType.Unchanged.ToString(), source);
+                    c.Tag = line;
+                }
+                else
+                {
+                    var c = viewer.AddNoWrap(null, null, null as string, ChangeType.Unchanged.ToString(), source);
+                    c.Tag = line;
+                }
+
                 continue;
             }
 
@@ -65,8 +76,17 @@ internal static class Helper
                     if (line.SubPieces != null && line.SubPieces.Count > 1 && !disableSubPieces)
                     {
                         var details = GetSubPiecesInfo(line, true);
-                        var c = viewer.Add(line.Position, "+", details, changeType.ToString(), source);
-                        c.Tag = line;
+                        if (diffViewer.IsTextWrapEnabled)
+                        {
+                            var c = viewer.Add(line.Position, "+", details, changeType.ToString(), source);
+                            c.Tag = line;
+                        }
+                        else
+                        {
+                            var c = viewer.AddNoWrap(line.Position, "+", details, changeType.ToString(), source);
+                            c.Tag = line;
+                        }
+
                         hasAdded = true;
                     }
 
@@ -75,8 +95,17 @@ internal static class Helper
                     if (line.SubPieces != null && line.SubPieces.Count > 1 && !disableSubPieces)
                     {
                         var details = GetSubPiecesInfo(line, false);
-                        var c = viewer.Add(line.Position, "-", details, changeType.ToString(), source);
-                        c.Tag = line;
+                        if (diffViewer.IsTextWrapEnabled)
+                        {
+                            var c = viewer.Add(line.Position, "-", details, changeType.ToString(), source);
+                            c.Tag = line;
+                        }
+                        else
+                        {
+                            var c = viewer.AddNoWrap(line.Position, "-", details, changeType.ToString(), source);
+                            c.Tag = line;
+                        }
+
                         hasAdded = true;
                     }
 
@@ -231,7 +260,7 @@ internal static class Helper
         catch (InvalidOperationException)
         {
         }
-        
+
         return false;
     }
 
@@ -478,12 +507,23 @@ internal static class Helper
 
     private static void InsertLinesInteral(InternalLinesViewer panel, List<DiffPiece> lines, bool isOld, UIElement source, bool disableSubPieces = false)
     {
+        var diffViewer = source as DiffViewer;
+
         foreach (var line in lines)
         {
             if (line == null)
             {
-                var c = panel.Add(null, null, null as string, ChangeType.Unchanged.ToString(), source);
-                c.Tag = line;
+                if (diffViewer.IsTextWrapEnabled)
+                {
+                    var c = panel.Add(null, null, null as string, ChangeType.Unchanged.ToString(), source);
+                    c.Tag = line;
+                }
+                else
+                {
+                    var c = panel.AddNoWrap(null, null, null as string, ChangeType.Unchanged.ToString(), source);
+                    c.Tag = line;
+                }
+
                 continue;
             }
 
@@ -497,8 +537,17 @@ internal static class Helper
                     if (line.SubPieces != null && line.SubPieces.Count > 1 && !disableSubPieces)
                     {
                         var details = GetSubPiecesInfo(line, isOld);
-                        var c = panel.Add(line.Position, isOld ? "-" : "+", details, changeType.ToString(), source);
-                        c.Tag = line;
+                        if (diffViewer.IsTextWrapEnabled)
+                        {
+                            var c = panel.Add(line.Position, isOld ? "-" : "+", details, changeType.ToString(), source);
+                            c.Tag = line;
+                        }
+                        else
+                        {
+                            var c = panel.AddNoWrap(line.Position, isOld ? "-" : "+", details, changeType.ToString(), source);
+                            c.Tag = line;
+                        }
+
                         hasAdded = true;
                     }
 
@@ -515,13 +564,26 @@ internal static class Helper
 
             if (!hasAdded)
             {
-                var c = panel.Add(line.Position, changeType switch
+                if (diffViewer.IsTextWrapEnabled)
                 {
-                    ChangeType.Inserted => "+",
-                    ChangeType.Deleted => "-",
-                    _ => " "
-                }, text, changeType.ToString(), source);
-                c.Tag = line;
+                    var c = panel.Add(line.Position, changeType switch
+                    {
+                        ChangeType.Inserted => "+",
+                        ChangeType.Deleted => "-",
+                        _ => " "
+                    }, text, changeType.ToString(), source);
+                    c.Tag = line;
+                }
+                else
+                {
+                    var c = panel.AddNoWrap(line.Position, changeType switch
+                    {
+                        ChangeType.Inserted => "+",
+                        ChangeType.Deleted => "-",
+                        _ => " "
+                    }, text, changeType.ToString(), source);
+                    c.Tag = line;
+                }
             }
         }
 

--- a/DiffPlex.Wpf/Controls/InternalLinesViewer.xaml
+++ b/DiffPlex.Wpf/Controls/InternalLinesViewer.xaml
@@ -1,126 +1,199 @@
-﻿<UserControl x:Class="DiffPlex.Wpf.Controls.InternalLinesViewer"
-             x:ClassModifier="internal"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:DiffPlex.Wpf.Controls"
-             mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
+﻿<UserControl
+    x:Class="DiffPlex.Wpf.Controls.InternalLinesViewer"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:DiffPlex.Wpf.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    x:ClassModifier="internal"
+    mc:Ignorable="d">
     <UserControl.Resources>
+        <local:BooleanToScrollBarVisibilityConverter x:Key="BooleanToScrollBarVisibilityConverter" />
         <ControlTemplate x:Key="LocalScrollViewerTemplate" TargetType="{x:Type ScrollViewer}">
             <Grid x:Name="Grid" Background="{TemplateBinding Background}">
-                <ScrollContentPresenter x:Name="PART_ScrollContentPresenter" CanContentScroll="{TemplateBinding CanContentScroll}" CanHorizontallyScroll="False" CanVerticallyScroll="False" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" Grid.Column="0" Margin="{TemplateBinding Padding}" Grid.Row="0"/>
-                <ScrollBar x:Name="PART_VerticalScrollBar" AutomationProperties.AutomationId="VerticalScrollBar" Cursor="Arrow" HorizontalAlignment="Right" Maximum="{TemplateBinding ScrollableHeight}" Minimum="0" Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}" Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" ViewportSize="{TemplateBinding ViewportHeight}" Style="{DynamicResource LocalScrollBarStyle}" Background="#99808080" BorderBrush="#99808080" Foreground="#FF808080"/>
-                <ScrollBar x:Name="PART_HorizontalScrollBar" AutomationProperties.AutomationId="HorizontalScrollBar" Cursor="Arrow" VerticalAlignment="Bottom" Margin="0,0,20,0" Maximum="{TemplateBinding ScrollableWidth}" Minimum="0" Orientation="Horizontal" Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}" Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" ViewportSize="{TemplateBinding ViewportWidth}" Style="{DynamicResource LocalScrollBarStyle}" Background="#99808080" BorderBrush="#99808080" Foreground="#FF808080"/>
+                <ScrollContentPresenter
+                    x:Name="PART_ScrollContentPresenter"
+                    Grid.Row="0"
+                    Grid.Column="0"
+                    Margin="{TemplateBinding Padding}"
+                    CanContentScroll="{TemplateBinding CanContentScroll}"
+                    CanHorizontallyScroll="False"
+                    CanVerticallyScroll="False"
+                    Content="{TemplateBinding Content}"
+                    ContentTemplate="{TemplateBinding ContentTemplate}" />
+                <ScrollBar
+                    x:Name="PART_VerticalScrollBar"
+                    HorizontalAlignment="Right"
+                    AutomationProperties.AutomationId="VerticalScrollBar"
+                    Background="#99808080"
+                    BorderBrush="#99808080"
+                    Cursor="Arrow"
+                    Foreground="#FF808080"
+                    Maximum="{TemplateBinding ScrollableHeight}"
+                    Minimum="0"
+                    Style="{DynamicResource LocalScrollBarStyle}"
+                    ViewportSize="{TemplateBinding ViewportHeight}"
+                    Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
+                    Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                <ScrollBar
+                    x:Name="PART_HorizontalScrollBar"
+                    Margin="0,0,20,0"
+                    VerticalAlignment="Bottom"
+                    AutomationProperties.AutomationId="HorizontalScrollBar"
+                    Background="#99808080"
+                    BorderBrush="#99808080"
+                    Cursor="Arrow"
+                    Foreground="#FF808080"
+                    Maximum="{TemplateBinding ScrollableWidth}"
+                    Minimum="0"
+                    Orientation="Horizontal"
+                    Style="{DynamicResource LocalScrollBarStyle}"
+                    ViewportSize="{TemplateBinding ViewportWidth}"
+                    Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
+                    Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
             </Grid>
         </ControlTemplate>
         <Style x:Key="ScrollBarButton" TargetType="{x:Type RepeatButton}">
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="HorizontalContentAlignment" Value="Center"/>
-            <Setter Property="VerticalContentAlignment" Value="Center"/>
-            <Setter Property="Padding" Value="1"/>
-            <Setter Property="Focusable" Value="false"/>
-            <Setter Property="IsTabStop" Value="false"/>
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Padding" Value="1" />
+            <Setter Property="Focusable" Value="false" />
+            <Setter Property="IsTabStop" Value="false" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type RepeatButton}">
-                        <Grid x:Name="grid" HorizontalAlignment="Stretch" Height="Auto" Margin="0" VerticalAlignment="Stretch" Opacity="0.6">
+                        <Grid
+                            x:Name="grid"
+                            Height="Auto"
+                            Margin="0"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            Opacity="0.6">
+                            <Rectangle
+                                x:Name="rectangle"
+                                Width="Auto"
+                                Height="Auto"
+                                Margin="0"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                Fill="{TemplateBinding Background}"
+                                Opacity="0"
+                                RadiusX="8"
+                                RadiusY="8" />
+                            <ContentPresenter
+                                x:Name="contentPresenter"
+                                Margin="0"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Focusable="False" />
                             <VisualStateManager.VisualStateGroups>
                                 <VisualStateGroup x:Name="CommonStates">
                                     <VisualState x:Name="Normal">
                                         <Storyboard>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="rectangle">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.4" Value="0"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="rectangle" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.4" Value="0" />
                                             </DoubleAnimationUsingKeyFrames>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="grid">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.4" Value="0.8"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="grid" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.4" Value="0.8" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualState>
                                     <VisualState x:Name="MouseOver">
                                         <Storyboard>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="rectangle">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0.2"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="rectangle" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0.2" />
                                             </DoubleAnimationUsingKeyFrames>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="grid">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="1"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="grid" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="1" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualState>
                                     <VisualState x:Name="Pressed">
                                         <Storyboard>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="rectangle">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0.4"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="rectangle" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0.4" />
                                             </DoubleAnimationUsingKeyFrames>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="grid">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0.9"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="grid" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0.9" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualState>
                                     <VisualState x:Name="Disabled">
                                         <Storyboard>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="grid">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.6" Value="0.4"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="grid" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.6" Value="0.4" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualState>
                                 </VisualStateGroup>
                             </VisualStateManager.VisualStateGroups>
-                            <Rectangle x:Name="rectangle" Fill="{TemplateBinding Background}" HorizontalAlignment="Stretch" Height="Auto" Margin="0" RadiusY="8" RadiusX="8" VerticalAlignment="Stretch" Width="Auto" Opacity="0"/>
-                            <ContentPresenter x:Name="contentPresenter" Focusable="False" Margin="0" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                         </Grid>
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
         </Style>
         <Style x:Key="RepeatButtonTransparent" TargetType="{x:Type RepeatButton}">
-            <Setter Property="OverridesDefaultStyle" Value="true"/>
-            <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="Focusable" Value="false"/>
-            <Setter Property="IsTabStop" Value="false"/>
+            <Setter Property="OverridesDefaultStyle" Value="true" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Focusable" Value="false" />
+            <Setter Property="IsTabStop" Value="false" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type RepeatButton}">
-                        <Rectangle Fill="{TemplateBinding Background}" Height="{TemplateBinding Height}" Width="{TemplateBinding Width}"/>
+                        <Rectangle
+                            Width="{TemplateBinding Width}"
+                            Height="{TemplateBinding Height}"
+                            Fill="{TemplateBinding Background}" />
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
         </Style>
         <Style x:Key="ScrollBarThumbVertical" TargetType="{x:Type Thumb}">
-            <Setter Property="OverridesDefaultStyle" Value="true"/>
-            <Setter Property="IsTabStop" Value="false"/>
+            <Setter Property="OverridesDefaultStyle" Value="true" />
+            <Setter Property="IsTabStop" Value="false" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type Thumb}">
-                        <Rectangle x:Name="rectangle" Fill="{TemplateBinding Foreground}" Height="{TemplateBinding Height}" StrokeThickness="0" SnapsToDevicePixels="True" Width="{TemplateBinding Width}" Opacity="0.3" RadiusX="8" RadiusY="4">
+                        <Rectangle
+                            x:Name="rectangle"
+                            Width="{TemplateBinding Width}"
+                            Height="{TemplateBinding Height}"
+                            Fill="{TemplateBinding Foreground}"
+                            Opacity="0.3"
+                            RadiusX="8"
+                            RadiusY="4"
+                            SnapsToDevicePixels="True"
+                            StrokeThickness="0">
                             <VisualStateManager.VisualStateGroups>
                                 <VisualStateGroup x:Name="CommonStates">
                                     <VisualState x:Name="Normal">
                                         <Storyboard>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="rectangle">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.4" Value="0.6"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="rectangle" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.4" Value="0.6" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualState>
                                     <VisualState x:Name="MouseOver">
                                         <Storyboard>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="rectangle">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="1"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="rectangle" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="1" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualState>
                                     <VisualState x:Name="Pressed">
                                         <Storyboard>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="rectangle">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0.8"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="rectangle" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0.8" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualState>
                                     <VisualState x:Name="Disabled">
                                         <Storyboard>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="rectangle">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.4" Value="0.3"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="rectangle" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.4" Value="0.3" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualState>
@@ -132,39 +205,48 @@
             </Setter>
         </Style>
         <Style x:Key="ScrollBarThumbHorizontal" TargetType="{x:Type Thumb}">
-            <Setter Property="OverridesDefaultStyle" Value="true"/>
-            <Setter Property="IsTabStop" Value="false"/>
+            <Setter Property="OverridesDefaultStyle" Value="true" />
+            <Setter Property="IsTabStop" Value="false" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type Thumb}">
-                        <Rectangle x:Name="rectangle" Fill="{TemplateBinding Foreground}" Height="{TemplateBinding Height}" SnapsToDevicePixels="True" Width="{TemplateBinding Width}" StrokeThickness="0" Opacity="0.3" RadiusX="4" RadiusY="8">
+                        <Rectangle
+                            x:Name="rectangle"
+                            Width="{TemplateBinding Width}"
+                            Height="{TemplateBinding Height}"
+                            Fill="{TemplateBinding Foreground}"
+                            Opacity="0.3"
+                            RadiusX="4"
+                            RadiusY="8"
+                            SnapsToDevicePixels="True"
+                            StrokeThickness="0">
                             <VisualStateManager.VisualStateGroups>
                                 <VisualStateGroup x:Name="CommonStates">
                                     <VisualState x:Name="Normal">
                                         <Storyboard>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="rectangle">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.4" Value="0.6"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="rectangle" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.4" Value="0.6" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualState>
                                     <VisualState x:Name="MouseOver">
                                         <Storyboard>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="rectangle">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="1"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="rectangle" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="1" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualState>
                                     <VisualState x:Name="Pressed">
                                         <Storyboard>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="rectangle">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0.8"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="rectangle" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0.8" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualState>
                                     <VisualState x:Name="Disabled">
                                         <Storyboard>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="rectangle">
-                                                <EasingDoubleKeyFrame KeyTime="0:0:0.6" Value="0.3"/>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="rectangle" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <EasingDoubleKeyFrame KeyTime="0:0:0.6" Value="0.3" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualState>
@@ -176,40 +258,71 @@
             </Setter>
         </Style>
         <Style x:Key="LocalScrollBarStyle" TargetType="{x:Type ScrollBar}">
-            <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false"/>
-            <Setter Property="Stylus.IsFlicksEnabled" Value="false"/>
-            <Setter Property="Background" Value="#44808080"/>
-            <Setter Property="BorderBrush" Value="#44808080"/>
-            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
-            <Setter Property="BorderThickness" Value="1,0"/>
-            <Setter Property="Width" Value="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
-            <Setter Property="MinWidth" Value="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
+            <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false" />
+            <Setter Property="Stylus.IsFlicksEnabled" Value="false" />
+            <Setter Property="Background" Value="#44808080" />
+            <Setter Property="BorderBrush" Value="#44808080" />
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+            <Setter Property="BorderThickness" Value="1,0" />
+            <Setter Property="Width" Value="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}" />
+            <Setter Property="MinWidth" Value="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type ScrollBar}">
                         <Grid x:Name="Bg" SnapsToDevicePixels="true">
                             <Grid.RowDefinitions>
-                                <RowDefinition MaxHeight="{DynamicResource {x:Static SystemParameters.VerticalScrollBarButtonHeightKey}}"/>
-                                <RowDefinition Height="0.00001*"/>
-                                <RowDefinition MaxHeight="{DynamicResource {x:Static SystemParameters.VerticalScrollBarButtonHeightKey}}"/>
+                                <RowDefinition MaxHeight="{DynamicResource {x:Static SystemParameters.VerticalScrollBarButtonHeightKey}}" />
+                                <RowDefinition Height="0.00001*" />
+                                <RowDefinition MaxHeight="{DynamicResource {x:Static SystemParameters.VerticalScrollBarButtonHeightKey}}" />
                             </Grid.RowDefinitions>
-                            <Border Grid.Row="1"/>
-                            <RepeatButton x:Name="PART_LineUpButton" Command="{x:Static ScrollBar.LineUpCommand}" Style="{StaticResource ScrollBarButton}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" Foreground="{TemplateBinding Foreground}">
-                                <Path x:Name="ArrowTop" Data="M 0,4 C0,4 0,6 0,6 0,6 3.5,2.5 3.5,2.5 3.5,2.5 7,6 7,6 7,6 7,4 7,4 7,4 3.5,0.5 3.5,0.5 3.5,0.5 0,4 0,4 z" Fill="{TemplateBinding Foreground}" Margin="3" Stretch="Uniform"/>
+                            <Border Grid.Row="1" />
+                            <RepeatButton
+                                x:Name="PART_LineUpButton"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                Command="{x:Static ScrollBar.LineUpCommand}"
+                                Foreground="{TemplateBinding Foreground}"
+                                Style="{StaticResource ScrollBarButton}">
+                                <Path
+                                    x:Name="ArrowTop"
+                                    Margin="3"
+                                    Data="M 0,4 C0,4 0,6 0,6 0,6 3.5,2.5 3.5,2.5 3.5,2.5 7,6 7,6 7,6 7,4 7,4 7,4 3.5,0.5 3.5,0.5 3.5,0.5 0,4 0,4 z"
+                                    Fill="{TemplateBinding Foreground}"
+                                    Stretch="Uniform" />
                             </RepeatButton>
-                            <Track x:Name="PART_Track" IsDirectionReversed="true" Grid.Row="1">
+                            <Track
+                                x:Name="PART_Track"
+                                Grid.Row="1"
+                                IsDirectionReversed="true">
                                 <Track.DecreaseRepeatButton>
-                                    <RepeatButton Command="{x:Static ScrollBar.PageUpCommand}" Style="{StaticResource RepeatButtonTransparent}"/>
+                                    <RepeatButton Command="{x:Static ScrollBar.PageUpCommand}" Style="{StaticResource RepeatButtonTransparent}" />
                                 </Track.DecreaseRepeatButton>
                                 <Track.IncreaseRepeatButton>
-                                    <RepeatButton Command="{x:Static ScrollBar.PageDownCommand}" Style="{StaticResource RepeatButtonTransparent}"/>
+                                    <RepeatButton Command="{x:Static ScrollBar.PageDownCommand}" Style="{StaticResource RepeatButtonTransparent}" />
                                 </Track.IncreaseRepeatButton>
                                 <Track.Thumb>
-                                    <Thumb Style="{StaticResource ScrollBarThumbVertical}" Background="{TemplateBinding Foreground}" Foreground="{TemplateBinding Foreground}" Margin="3,0" Opacity="0.8"/>
+                                    <Thumb
+                                        Margin="3,0"
+                                        Background="{TemplateBinding Foreground}"
+                                        Foreground="{TemplateBinding Foreground}"
+                                        Opacity="0.8"
+                                        Style="{StaticResource ScrollBarThumbVertical}" />
                                 </Track.Thumb>
                             </Track>
-                            <RepeatButton x:Name="PART_LineDownButton" Command="{x:Static ScrollBar.LineDownCommand}" Grid.Row="2" Style="{StaticResource ScrollBarButton}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" Foreground="{TemplateBinding Foreground}">
-                                <Path x:Name="ArrowBottom" Data="M 0,2.5 C0,2.5 0,0.5 0,0.5 0,0.5 3.5,4 3.5,4 3.5,4 7,0.5 7,0.5 7,0.5 7,2.5 7,2.5 7,2.5 3.5,6 3.5,6 3.5,6 0,2.5 0,2.5 z" Fill="{TemplateBinding Foreground}" Margin="3" Stretch="Uniform"/>
+                            <RepeatButton
+                                x:Name="PART_LineDownButton"
+                                Grid.Row="2"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                Command="{x:Static ScrollBar.LineDownCommand}"
+                                Foreground="{TemplateBinding Foreground}"
+                                Style="{StaticResource ScrollBarButton}">
+                                <Path
+                                    x:Name="ArrowBottom"
+                                    Margin="3"
+                                    Data="M 0,2.5 C0,2.5 0,0.5 0,0.5 0,0.5 3.5,4 3.5,4 3.5,4 7,0.5 7,0.5 7,0.5 7,2.5 7,2.5 7,2.5 3.5,6 3.5,6 3.5,6 0,2.5 0,2.5 z"
+                                    Fill="{TemplateBinding Foreground}"
+                                    Stretch="Uniform" />
                             </RepeatButton>
                         </Grid>
                     </ControlTemplate>
@@ -217,37 +330,65 @@
             </Setter>
             <Style.Triggers>
                 <Trigger Property="Orientation" Value="Horizontal">
-                    <Setter Property="Width" Value="Auto"/>
-                    <Setter Property="MinWidth" Value="0"/>
-                    <Setter Property="Height" Value="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarHeightKey}}"/>
-                    <Setter Property="MinHeight" Value="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarHeightKey}}"/>
-                    <Setter Property="BorderThickness" Value="0,1"/>
+                    <Setter Property="Width" Value="Auto" />
+                    <Setter Property="MinWidth" Value="0" />
+                    <Setter Property="Height" Value="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarHeightKey}}" />
+                    <Setter Property="MinHeight" Value="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarHeightKey}}" />
+                    <Setter Property="BorderThickness" Value="0,1" />
                     <Setter Property="Template">
                         <Setter.Value>
                             <ControlTemplate TargetType="{x:Type ScrollBar}">
                                 <Grid x:Name="Bg" SnapsToDevicePixels="true">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition MaxWidth="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarButtonWidthKey}}"/>
-                                        <ColumnDefinition Width="0.00001*"/>
-                                        <ColumnDefinition MaxWidth="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarButtonWidthKey}}"/>
+                                        <ColumnDefinition MaxWidth="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarButtonWidthKey}}" />
+                                        <ColumnDefinition Width="0.00001*" />
+                                        <ColumnDefinition MaxWidth="{DynamicResource {x:Static SystemParameters.HorizontalScrollBarButtonWidthKey}}" />
                                     </Grid.ColumnDefinitions>
-                                    <Border Grid.Row="1"/>
-                                    <RepeatButton x:Name="PART_LineLeftButton" Command="{x:Static ScrollBar.LineLeftCommand}" Style="{StaticResource ScrollBarButton}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" Foreground="{TemplateBinding Foreground}">
-                                        <Path x:Name="ArrowLeft" Data="M 3.18,7 C3.18,7 5,7 5,7 5,7 1.81,3.5 1.81,3.5 1.81,3.5 5,0 5,0 5,0 3.18,0 3.18,0 3.18,0 0,3.5 0,3.5 0,3.5 3.18,7 3.18,7 z" Fill="{TemplateBinding Foreground}" Margin="3" Stretch="Uniform"/>
+                                    <Border Grid.Row="1" />
+                                    <RepeatButton
+                                        x:Name="PART_LineLeftButton"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        Command="{x:Static ScrollBar.LineLeftCommand}"
+                                        Foreground="{TemplateBinding Foreground}"
+                                        Style="{StaticResource ScrollBarButton}">
+                                        <Path
+                                            x:Name="ArrowLeft"
+                                            Margin="3"
+                                            Data="M 3.18,7 C3.18,7 5,7 5,7 5,7 1.81,3.5 1.81,3.5 1.81,3.5 5,0 5,0 5,0 3.18,0 3.18,0 3.18,0 0,3.5 0,3.5 0,3.5 3.18,7 3.18,7 z"
+                                            Fill="{TemplateBinding Foreground}"
+                                            Stretch="Uniform" />
                                     </RepeatButton>
                                     <Track x:Name="PART_Track" Grid.Column="1">
                                         <Track.DecreaseRepeatButton>
-                                            <RepeatButton Command="{x:Static ScrollBar.PageLeftCommand}" Style="{StaticResource RepeatButtonTransparent}"/>
+                                            <RepeatButton Command="{x:Static ScrollBar.PageLeftCommand}" Style="{StaticResource RepeatButtonTransparent}" />
                                         </Track.DecreaseRepeatButton>
                                         <Track.IncreaseRepeatButton>
-                                            <RepeatButton Command="{x:Static ScrollBar.PageRightCommand}" Style="{StaticResource RepeatButtonTransparent}"/>
+                                            <RepeatButton Command="{x:Static ScrollBar.PageRightCommand}" Style="{StaticResource RepeatButtonTransparent}" />
                                         </Track.IncreaseRepeatButton>
                                         <Track.Thumb>
-                                            <Thumb Style="{StaticResource ScrollBarThumbHorizontal}" Background="{TemplateBinding Foreground}" Foreground="{TemplateBinding Foreground}" Margin="0,3" Opacity="0.8"/>
+                                            <Thumb
+                                                Margin="0,3"
+                                                Background="{TemplateBinding Foreground}"
+                                                Foreground="{TemplateBinding Foreground}"
+                                                Opacity="0.8"
+                                                Style="{StaticResource ScrollBarThumbHorizontal}" />
                                         </Track.Thumb>
                                     </Track>
-                                    <RepeatButton x:Name="PART_LineRightButton" Grid.Column="2" Command="{x:Static ScrollBar.LineRightCommand}" Style="{StaticResource ScrollBarButton}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" Foreground="{TemplateBinding Foreground}">
-                                        <Path x:Name="ArrowRight" Data="M 1.81,7 C1.81,7 0,7 0,7 0,7 3.18,3.5 3.18,3.5 3.18,3.5 0,0 0,0 0,0 1.81,0 1.81,0 1.81,0 5,3.5 5,3.5 5,3.5 1.81,7 1.81,7 z" Fill="{TemplateBinding Foreground}" Margin="3" Stretch="Uniform"/>
+                                    <RepeatButton
+                                        x:Name="PART_LineRightButton"
+                                        Grid.Column="2"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        Command="{x:Static ScrollBar.LineRightCommand}"
+                                        Foreground="{TemplateBinding Foreground}"
+                                        Style="{StaticResource ScrollBarButton}">
+                                        <Path
+                                            x:Name="ArrowRight"
+                                            Margin="3"
+                                            Data="M 1.81,7 C1.81,7 0,7 0,7 0,7 3.18,3.5 3.18,3.5 3.18,3.5 0,0 0,0 0,0 1.81,0 1.81,0 1.81,0 5,3.5 5,3.5 5,3.5 1.81,7 1.81,7 z"
+                                            Fill="{TemplateBinding Foreground}"
+                                            Stretch="Uniform" />
                                     </RepeatButton>
                                 </Grid>
                             </ControlTemplate>
@@ -257,21 +398,36 @@
             </Style.Triggers>
         </Style>
     </UserControl.Resources>
-    
+
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition x:Name="NumberColumn" Width="40"/>
-            <ColumnDefinition x:Name="OperationColumn" Width="20"/>
-            <ColumnDefinition x:Name="ValueColumn" Width="1*"/>
+            <ColumnDefinition x:Name="NumberColumn" Width="40" />
+            <ColumnDefinition x:Name="OperationColumn" Width="20" />
+            <ColumnDefinition x:Name="ValueColumn" Width="1*" />
         </Grid.ColumnDefinitions>
-        <ScrollViewer x:Name="NumberScrollViewer" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden" ScrollChanged="NumberScrollViewer_ScrollChanged">
-            <StackPanel x:Name="NumberPanel"/>
+        <ScrollViewer
+            x:Name="NumberScrollViewer"
+            HorizontalScrollBarVisibility="Hidden"
+            ScrollChanged="NumberScrollViewer_ScrollChanged"
+            VerticalScrollBarVisibility="Hidden">
+            <StackPanel x:Name="NumberPanel" />
         </ScrollViewer>
-        <ScrollViewer x:Name="OperationScrollViewer" Grid.Column="1" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden" ScrollChanged="OperationScrollViewer_ScrollChanged">
-            <StackPanel x:Name="OperationPanel"/>
+        <ScrollViewer
+            x:Name="OperationScrollViewer"
+            Grid.Column="1"
+            HorizontalScrollBarVisibility="Hidden"
+            ScrollChanged="OperationScrollViewer_ScrollChanged"
+            VerticalScrollBarVisibility="Hidden">
+            <StackPanel x:Name="OperationPanel" />
         </ScrollViewer>
-        <ScrollViewer Template="{DynamicResource LocalScrollViewerTemplate}" x:Name="ValueScrollViewer" Grid.Column="2" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" ScrollChanged="ValueScrollViewer_ScrollChanged" SizeChanged="ValueScrollViewer_SizeChanged">
-            <StackPanel x:Name="ValuePanel"/>
+        <ScrollViewer
+            x:Name="ValueScrollViewer"
+            Grid.Column="2"
+            ScrollChanged="ValueScrollViewer_ScrollChanged"
+            SizeChanged="ValueScrollViewer_SizeChanged"
+            Template="{DynamicResource LocalScrollViewerTemplate}"
+            VerticalScrollBarVisibility="Auto">
+            <StackPanel x:Name="ValuePanel" />
         </ScrollViewer>
     </Grid>
 </UserControl>

--- a/DiffPlex.Wpf/DiffWindow.xaml.cs
+++ b/DiffPlex.Wpf/DiffWindow.xaml.cs
@@ -296,5 +296,11 @@ namespace DiffPlex.Wpf
         /// <param name="template">The control template to set.</param>
         public void SetMenuTextBoxTemlate(ControlTemplate template)
             => DiffView.SetMenuTextBoxTemlate(template);
+
+        /// <summary>
+        /// Enables text wrapping for the text blocks in the diff viewer.
+        /// </summary>
+        public void EnableTextWrapping()
+            => DiffView.EnableTextWrapping();
     }
 }


### PR DESCRIPTION
Added the ability to wrap text by calling `DiffView.EnableTextWrapping()`. This addresses issue #113 

Below is an example of the text wrapping:
https://github.com/user-attachments/assets/53d3d13e-6338-4336-92f9-a566412f1fbc

