### PR TITLE
Modernization

### DIFF
--- a/DiffPlex.App/DiffPlex.App.csproj
+++ b/DiffPlex.App/DiffPlex.App.csproj
@@ -3,16 +3,16 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <WindowsSdkPackageVersion>10.0.19041.48</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.19041.57</WindowsSdkPackageVersion>
     <RootNamespace>DiffPlex.UI</RootNamespace>
     <AssemblyName>DiffPlex.App</AssemblyName>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <PackageTags>diff</PackageTags>
     <Description>Diff files and text.</Description>
     <LangVersion>13.0</LangVersion>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <FileVersion>1.3.0.0</FileVersion>
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/DiffPlex.App/DiffPlex.App.csproj
+++ b/DiffPlex.App/DiffPlex.App.csproj
@@ -7,12 +7,12 @@
     <RootNamespace>DiffPlex.UI</RootNamespace>
     <AssemblyName>DiffPlex.App</AssemblyName>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <Version>1.3.0</Version>
+    <Version>2.0.0</Version>
     <PackageTags>diff</PackageTags>
     <Description>Diff files and text.</Description>
     <LangVersion>13.0</LangVersion>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
-    <FileVersion>1.3.0.0</FileVersion>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>

--- a/DiffPlex.App/Package.appxmanifest
+++ b/DiffPlex.App/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="ea50cd11-3ec2-4c0f-a744-2ec6e937e6ea"
     Publisher="CN=mmanela"
-    Version="1.3.0.0" />
+    Version="2.0.0.0" />
 
   <Properties>
     <DisplayName>DiffPlex</DisplayName>

--- a/DiffPlex.App/Package.appxmanifest
+++ b/DiffPlex.App/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="ea50cd11-3ec2-4c0f-a744-2ec6e937e6ea"
     Publisher="CN=mmanela"
-    Version="1.0.0.0" />
+    Version="1.3.0.0" />
 
   <Properties>
     <DisplayName>DiffPlex</DisplayName>

--- a/DiffPlex.Windows/Converters.cs
+++ b/DiffPlex.Windows/Converters.cs
@@ -38,7 +38,7 @@ public class DiffChangeTypeConverter(ChangeType defaultChangeType) : IValueConve
         {
             if (targetType == typeof(IEnumerable<TextHighlighter>))
             {
-                if (value is not List<DiffPiece> sub)
+                if (value is not IEnumerable<DiffPiece> sub)
                 {
                     if (value is not DiffPiece diffPiece) return null;
                     sub = diffPiece.SubPieces;
@@ -144,7 +144,7 @@ public class DiffTextHighlighterConverter(ChangeType defaultChangeType) : IValue
     public object Convert(object value, Type targetType, object parameter, string language)
     {
         if (value is FrameworkElement element) value = element.DataContext;
-        if (value is not List<DiffPiece> sub)
+        if (value is not IEnumerable<DiffPiece> sub)
         {
             if (value is DiffPiece p) sub = p.SubPieces;
             else return null;

--- a/DiffPlex.Windows/DiffPlex.Windows.csproj
+++ b/DiffPlex.Windows/DiffPlex.Windows.csproj
@@ -7,13 +7,13 @@
     <PackageId>DiffPlex.Windows</PackageId>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <PackageTags>diff</PackageTags>
     <PackageIcon>diffplex_icon.png</PackageIcon>
     <Description>DiffPlex.Windows is a Windows App SDK control library that allows you to programatically render visual text diffs in your application.</Description>
     <LangVersion>13.0</LangVersion>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <FileVersion>1.3.0.0</FileVersion>
     <Authors>Kingcean Tuan; Matthew Manela</Authors>
     <Copyright>Copyright (c) 2022 Matthew Manela. All rights reserved.</Copyright>
     <ApplicationIcon>../DiffPlex.ico</ApplicationIcon>
@@ -35,10 +35,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
-    <PackageReference Include="Trivial.WindowsKit" Version="9.2.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
+    <PackageReference Include="Trivial.WindowsKit" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DiffPlex.Windows/DiffPlex.Windows.csproj
+++ b/DiffPlex.Windows/DiffPlex.Windows.csproj
@@ -7,13 +7,13 @@
     <PackageId>DiffPlex.Windows</PackageId>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
-    <Version>1.3.0</Version>
+    <Version>2.0.0</Version>
     <PackageTags>diff</PackageTags>
     <PackageIcon>diffplex_icon.png</PackageIcon>
     <Description>DiffPlex.Windows is a Windows App SDK control library that allows you to programatically render visual text diffs in your application.</Description>
     <LangVersion>13.0</LangVersion>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
-    <FileVersion>1.3.0.0</FileVersion>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
     <Authors>Kingcean Tuan; Matthew Manela</Authors>
     <Copyright>Copyright (c) 2022 Matthew Manela. All rights reserved.</Copyright>
     <ApplicationIcon>../DiffPlex.ico</ApplicationIcon>

--- a/DiffPlex.Windows/DiffTextView.xaml.cs
+++ b/DiffPlex.Windows/DiffTextView.xaml.cs
@@ -149,7 +149,7 @@ public sealed partial class DiffTextView : UserControl
 
     private readonly DiffTextViewReference reference;
     private List<DiffTextViewModel> sideBySide;
-    private List<DiffPiece> inlines;
+    private IReadOnlyList<DiffPiece> inlines;
     private bool skipRefresh = true;
 
     /// <summary>
@@ -815,8 +815,8 @@ public sealed partial class DiffTextView : UserControl
         if (SplitElement.ItemsSource != null && !forceToUpdate) return;
         sideBySide = null;
         var diff = SideBySideDiffBuilder.Diff(OldText ?? string.Empty, NewText ?? string.Empty, IgnoreWhiteSpace, !IsCaseSensitive);
-        var left = diff?.OldText?.Lines ?? new();
-        var right = diff?.NewText?.Lines ?? new();
+        var left = diff?.OldText?.Lines ?? new List<DiffPiece>();
+        var right = diff?.NewText?.Lines ?? new List<DiffPiece>();
         var count = Math.Max(left.Count, right.Count);
         var col = new List<DiffTextViewModel>();
         var add = 0;

--- a/DiffPlex.Windows/Helper.cs
+++ b/DiffPlex.Windows/Helper.cs
@@ -25,7 +25,7 @@ internal class InternalUtilities
 
     public static readonly SolidColorBrush GrayBackground = new(Color.FromArgb(32, 128, 128, 128));
 
-    public static List<TextHighlighter> GetTextHighlighter(List<DiffPiece> sub, ChangeType modify, Brush foreground)
+    public static List<TextHighlighter> GetTextHighlighter(IEnumerable<DiffPiece> sub, ChangeType modify, Brush foreground)
     {
         if (sub == null) return null;
         var insert = new TextHighlighter

--- a/DiffPlex.WindowsForms.Demo/DiffPlex.WindowsForms.Demo.csproj
+++ b/DiffPlex.WindowsForms.Demo/DiffPlex.WindowsForms.Demo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net8.0-windows;net48;net46</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net48;net462</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <ApplicationIcon>..\DiffPlex.ico</ApplicationIcon>

--- a/DiffPlex.Wpf.Demo/DiffPlex.Wpf.Demo.csproj
+++ b/DiffPlex.Wpf.Demo/DiffPlex.Wpf.Demo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net9.0-windows;net8.0-windows;net48;net46</TargetFrameworks>
+    <TargetFrameworks>net9.0-windows;net8.0-windows;net48;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <StartupObject>DiffPlex.Wpf.Demo.App</StartupObject>

--- a/DiffPlex.Wpf/Controls/DiffViewer.xaml.cs
+++ b/DiffPlex.Wpf/Controls/DiffViewer.xaml.cs
@@ -1183,12 +1183,12 @@ public partial class DiffViewer : UserControl
 
     private void ApplyHeaderTextProperties(TextBlock text)
     {
-        text.SetBinding(TextBlock.FontSizeProperty, new Binding("FontSize") { Source = this, Mode = BindingMode.OneWay });
-        text.SetBinding(TextBlock.FontFamilyProperty, new Binding("FontFamily") { Source = this, Mode = BindingMode.OneWay });
-        text.SetBinding(TextBlock.FontWeightProperty, new Binding("FontWeight") { Source = this, Mode = BindingMode.OneWay });
-        text.SetBinding(TextBlock.FontStretchProperty, new Binding("FontStretch") { Source = this, Mode = BindingMode.OneWay });
-        text.SetBinding(TextBlock.FontStyleProperty, new Binding("FontStyle") { Source = this, Mode = BindingMode.OneWay });
-        text.SetBinding(TextBlock.ForegroundProperty, new Binding("HeaderForeground") { Source = this, Mode = BindingMode.OneWay, TargetNullValue = Foreground });
+        text.SetBinding(TextBlock.FontSizeProperty, new Binding(nameof(FontSize)) { Source = this, Mode = BindingMode.OneWay });
+        text.SetBinding(TextBlock.FontFamilyProperty, new Binding(nameof(FontFamily)) { Source = this, Mode = BindingMode.OneWay });
+        text.SetBinding(TextBlock.FontWeightProperty, new Binding(nameof(FontWeight)) { Source = this, Mode = BindingMode.OneWay });
+        text.SetBinding(TextBlock.FontStretchProperty, new Binding(nameof(FontStretch)) { Source = this, Mode = BindingMode.OneWay });
+        text.SetBinding(TextBlock.FontStyleProperty, new Binding(nameof(FontStyle)) { Source = this, Mode = BindingMode.OneWay });
+        text.SetBinding(TextBlock.ForegroundProperty, new Binding(nameof(HeaderForeground)) { Source = this, Mode = BindingMode.OneWay, TargetNullValue = Foreground });
     }
 
     private void UpdateHeaderText()

--- a/DiffPlex.Wpf/Controls/DiffViewer.xaml.cs
+++ b/DiffPlex.Wpf/Controls/DiffViewer.xaml.cs
@@ -1163,7 +1163,7 @@ public partial class DiffViewer : UserControl
     private void RenderInlineDiffs()
     {
         if (inlineResult?.Lines == null) return;
-        ICollection<DiffPiece> selectedLines = inlineResult.Lines;
+        IReadOnlyCollection<DiffPiece> selectedLines = inlineResult.Lines;
         Helper.RenderInlineDiffs(InlineContentPanel, selectedLines, this, IgnoreUnchanged ? LinesContext : -1);
     }
 

--- a/DiffPlex.Wpf/Controls/Helper.cs
+++ b/DiffPlex.Wpf/Controls/Helper.cs
@@ -17,7 +17,7 @@ internal static class Helper
     /// <summary>
     /// Updates the inline diffs view.
     /// </summary>
-    internal static void RenderInlineDiffs(InternalLinesViewer viewer, ICollection<DiffPiece> lines, UIElement source, int contextLineCount)
+    internal static void RenderInlineDiffs(InternalLinesViewer viewer, IReadOnlyCollection<DiffPiece> lines, UIElement source, int contextLineCount)
     {
         viewer.Clear();
         if (lines == null) return;
@@ -84,7 +84,7 @@ internal static class Helper
         viewer.AdjustScrollView();
     }
 
-    internal static void InsertLines(InternalLinesViewer panel, List<DiffPiece> lines, bool isOld, UIElement source, int contextLineCount)
+    internal static void InsertLines(InternalLinesViewer panel, IReadOnlyCollection<DiffPiece> lines, bool isOld, UIElement source, int contextLineCount)
     {
         if (lines == null || panel == null) return;
         var guid = panel.TrackingId = Guid.NewGuid();
@@ -98,7 +98,7 @@ internal static class Helper
         _ = InsertLinesAsync(guid, panel, lines, isOld, source, contextLineCount);
     }
 
-    private static async Task InsertLinesAsync(Guid guid, InternalLinesViewer panel, List<DiffPiece> lines, bool isOld, UIElement source, int contextLineCount)
+    private static async Task InsertLinesAsync(Guid guid, InternalLinesViewer panel, IReadOnlyCollection<DiffPiece> lines, bool isOld, UIElement source, int contextLineCount)
     {   // For performance.
         if (lines == null || panel == null) return;
         var disablePieces = lines.Count > MaxCount;
@@ -474,7 +474,7 @@ internal static class Helper
         return details;
     }
 
-    private static void InsertLinesInteral(InternalLinesViewer panel, List<DiffPiece> lines, bool isOld, UIElement source, bool disableSubPieces = false)
+    private static void InsertLinesInteral(InternalLinesViewer panel, IReadOnlyCollection<DiffPiece> lines, bool isOld, UIElement source, bool disableSubPieces = false)
     {
         foreach (var line in lines)
         {

--- a/DiffPlex.Wpf/Controls/InlineDiffViewer.xaml.cs
+++ b/DiffPlex.Wpf/Controls/InlineDiffViewer.xaml.cs
@@ -171,7 +171,7 @@ public partial class InlineDiffViewer : UserControl
     /// <summary>
     /// Gets the lines in the diff model.
     /// </summary>
-    public IReadOnlyList<DiffPiece> Lines => DiffModel?.Lines?.AsReadOnly();
+    public IReadOnlyList<DiffPiece> Lines => DiffModel?.Lines;
 
     /// <summary>
     /// Gets or sets the foreground brush of the line number.

--- a/DiffPlex.Wpf/DiffPlex.Wpf.csproj
+++ b/DiffPlex.Wpf/DiffPlex.Wpf.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NuGet.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0-windows;net8.0-windows;net6.0-windows;net46;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0-windows;net8.0-windows;net6.0-windows;net462;net48</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <RootNamespace>DiffPlex.Wpf</RootNamespace>
     <AssemblyName>DiffPlex.Wpf</AssemblyName>
     <PackageTags>diff, wpf</PackageTags>
     <Description>DiffPlex.Wpf is a WPF control library that allows you to programatically render visual text diffs in your application. It also provide a diff viewer control used in Windows Forms application.</Description>
-    <AssemblyVersion>1.5.0.0</AssemblyVersion>
-    <FileVersion>1.5.0.0</FileVersion>
+    <AssemblyVersion>1.6.0.0</AssemblyVersion>
+    <FileVersion>1.6.0.0</FileVersion>
     <ApplicationIcon>..\DiffPlex.ico</ApplicationIcon>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
@@ -41,7 +41,7 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0-windows' AND '$(TargetFramework)' != 'net6.0-windows' AND '$(TargetFramework)' != 'net46' AND '$(TargetFramework)' != 'net48'" >
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0-windows' AND '$(TargetFramework)' != 'net6.0-windows' AND '$(TargetFramework)' != 'net46' AND '$(TargetFramework)' != 'net462' AND '$(TargetFramework)' != 'net48'" >
     <Compile Remove="Forms\*.cs" />
     <EmbeddedResource Remove="Forms\*.resx" />
   </ItemGroup>

--- a/DiffPlex.sln
+++ b/DiffPlex.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		azure-pipelines.yml = azure-pipelines.yml
+		Directory.Packages.props = Directory.Packages.props
 		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
 		global.json = global.json
 		License.txt = License.txt

--- a/DiffPlex/Chunkers/CharacterChunker.cs
+++ b/DiffPlex/Chunkers/CharacterChunker.cs
@@ -1,19 +1,31 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
-namespace DiffPlex.Chunkers
+namespace DiffPlex.Chunkers;
+
+public class CharacterChunker : IChunker
+#if !NET_TOO_OLD_VER
+    , ISpanChunker
+#endif
 {
-    public class CharacterChunker:IChunker
-    {
-        /// <summary>
-        /// Gets the default singleton instance of the chunker.
-        /// </summary>
-        public static CharacterChunker Instance { get; } = new CharacterChunker();
+    /// <summary>
+    /// Gets the default singleton instance of the chunker.
+    /// </summary>
+    public static CharacterChunker Instance { get; } = new CharacterChunker();
 
-        public IReadOnlyList<string> Chunk(string text)
-        {
-            var s = new string[text.Length];
-            for (int i = 0; i < text.Length; i++) s[i] = text[i].ToString();
-            return s;
-        }
+    public IReadOnlyList<string> Chunk(string text)
+    {
+        var s = new string[text.Length];
+        for (int i = 0; i < text.Length; i++) s[i] = text[i].ToString();
+        return s;
     }
+
+#if !NET_TOO_OLD_VER
+    public IReadOnlyList<string> Chunk(ReadOnlySpan<char> text)
+    {
+        var list = new List<string>();
+        for (int i = 0; i < text.Length; i++) list.Add(text[i].ToString());
+        return list;
+    }
+#endif
 }

--- a/DiffPlex/Chunkers/CustomFunctionChunker.cs
+++ b/DiffPlex/Chunkers/CustomFunctionChunker.cs
@@ -1,21 +1,30 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace DiffPlex.Chunkers
+namespace DiffPlex.Chunkers;
+
+public class CustomFunctionChunker : IChunker
+#if !NET_TOO_OLD_VER
+    , ISpanChunker
+#endif
 {
-    public class CustomFunctionChunker: IChunker
+    private readonly Func<string, IReadOnlyList<string>> customChunkerFunc;
+
+    public CustomFunctionChunker(Func<string, IReadOnlyList<string>> customChunkerFunc)
     {
-        private readonly Func<string, IReadOnlyList<string>> customChunkerFunc;
-
-        public CustomFunctionChunker(Func<string, IReadOnlyList<string>> customChunkerFunc)
-        {
-            if (customChunkerFunc == null) throw new ArgumentNullException(nameof(customChunkerFunc));
-            this.customChunkerFunc = customChunkerFunc;
-        }
-
-        public IReadOnlyList<string> Chunk(string text)
-        {
-            return customChunkerFunc(text);
-        }
+        if (customChunkerFunc == null) throw new ArgumentNullException(nameof(customChunkerFunc));
+        this.customChunkerFunc = customChunkerFunc;
     }
+
+    public IReadOnlyList<string> Chunk(string text)
+    {
+        return customChunkerFunc(text);
+    }
+
+#if !NET_TOO_OLD_VER
+    public IReadOnlyList<string> Chunk(ReadOnlySpan<char> text)
+    {
+        return customChunkerFunc(text.ToString());
+    }
+#endif
 }

--- a/DiffPlex/Chunkers/DelimiterChunker.cs
+++ b/DiffPlex/Chunkers/DelimiterChunker.cs
@@ -1,82 +1,148 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace DiffPlex.Chunkers
+namespace DiffPlex.Chunkers;
+
+public class DelimiterChunker : IChunker
+#if !NET_TOO_OLD_VER
+    , ISpanChunker
+#endif
 {
-    public class DelimiterChunker : IChunker
+    private readonly char[] delimiters;
+
+    public DelimiterChunker(char[] delimiters)
     {
-        private readonly char[] delimiters;
-
-        public DelimiterChunker(char[] delimiters)
+        if (delimiters is null || delimiters.Length == 0)
         {
-            if (delimiters is null || delimiters.Length == 0)
-            {
-                throw new ArgumentException($"{nameof(delimiters)} cannot be null or empty.", nameof(delimiters));
-            }
-
-            this.delimiters = delimiters;
+            throw new ArgumentException($"{nameof(delimiters)} cannot be null or empty.", nameof(delimiters));
         }
 
-        public IReadOnlyList<string> Chunk(string str)
+        this.delimiters = delimiters;
+    }
+
+    public IReadOnlyList<string> Chunk(string str)
+    {
+        var list = new List<string>();
+        var begin = 0;
+        var processingDelim = false;
+        var delimBegin = 0;
+        for (var i = 0; i < str.Length; i++)
         {
-            var list = new List<string>();
-            int begin = 0;
-            bool processingDelim = false;
-            int delimBegin = 0;
-            for (int i = 0; i < str.Length; i++)
+            if (Array.IndexOf(delimiters, str[i]) != -1)
             {
-                if (Array.IndexOf(delimiters, str[i]) != -1)
-                {
-                    if (i >= str.Length - 1)
-                    {
-                        if (processingDelim)
-                        {
-                            list.Add(str.Substring(delimBegin, (i + 1 - delimBegin)));
-                        }
-                        else
-                        {
-                            list.Add(str.Substring(begin, (i - begin)));
-                            list.Add(str.Substring(i, 1));
-                        }
-                    }
-                    else
-                    {
-                        if (!processingDelim)
-                        {
-                            // Add everything up to this delimeter as the next chunk (if there is anything)
-                            if (i - begin > 0)
-                            {
-                                list.Add(str.Substring(begin, (i - begin)));
-                            }
-
-                            processingDelim = true;
-                            delimBegin = i;
-                        }
-                    }
-
-                    begin = i + 1;
-                }
-                else
+                if (i >= str.Length - 1)
                 {
                     if (processingDelim)
                     {
-                        if (i - delimBegin > 0)
-                        {
-                            list.Add(str.Substring(delimBegin, (i - delimBegin)));
-                        }
-
-                        processingDelim = false;
+                        list.Add(str.Substring(delimBegin, i + 1 - delimBegin));
                     }
-
-                    // If we are at the end, add the remaining as the last chunk
-                    if (i >= str.Length - 1)
+                    else
                     {
-                        list.Add(str.Substring(begin, (i + 1 - begin)));
+                        list.Add(str.Substring(begin, i - begin));
+                        list.Add(str.Substring(i, 1));
                     }
                 }
-            }
+                else
+                {
+                    if (!processingDelim)
+                    {
+                        // Add everything up to this delimeter as the next chunk (if there is anything)
+                        if (i - begin > 0)
+                        {
+                            list.Add(str.Substring(begin, i - begin));
+                        }
 
-            return list;
+                        processingDelim = true;
+                        delimBegin = i;
+                    }
+                }
+
+                begin = i + 1;
+            }
+            else
+            {
+                if (processingDelim)
+                {
+                    if (i - delimBegin > 0)
+                    {
+                        list.Add(str.Substring(delimBegin, i - delimBegin));
+                    }
+
+                    processingDelim = false;
+                }
+
+                // If we are at the end, add the remaining as the last chunk
+                if (i >= str.Length - 1)
+                {
+                    list.Add(str.Substring(begin, i + 1 - begin));
+                }
+            }
         }
+
+        return list;
     }
+
+#if !NET_TOO_OLD_VER
+    public IReadOnlyList<string> Chunk(ReadOnlySpan<char> str)
+    {
+        var list = new List<string>();
+        var begin = 0;
+        var processingDelim = false;
+        var delimBegin = 0;
+        for (var i = 0; i < str.Length; i++)
+        {
+            if (Array.IndexOf(delimiters, str[i]) != -1)
+            {
+                if (i >= str.Length - 1)
+                {
+                    if (processingDelim)
+                    {
+                        list.Add(str.Slice(delimBegin, i + 1 - delimBegin).ToString());
+                    }
+                    else
+                    {
+                        list.Add(str.Slice(begin, i - begin).ToString());
+                        list.Add(str.Slice(i, 1).ToString());
+                    }
+                }
+                else
+                {
+                    if (!processingDelim)
+                    {
+                        // Add everything up to this delimeter as the next chunk (if there is anything)
+                        if (i - begin > 0)
+                        {
+                            list.Add(str.Slice(begin, i - begin).ToString());
+                        }
+
+                        processingDelim = true;
+                        delimBegin = i;
+                    }
+                }
+
+                begin = i + 1;
+            }
+            else
+            {
+                if (processingDelim)
+                {
+                    if (i - delimBegin > 0)
+                    {
+                        list.Add(str.Slice(delimBegin, i - delimBegin).ToString());
+                    }
+
+                    processingDelim = false;
+                }
+
+                // If we are at the end, add the remaining as the last chunk
+                if (i >= str.Length - 1)
+                {
+                    list.Add(str.Slice(begin, i + 1 - begin).ToString());
+                }
+            }
+        }
+
+        return list;
+    }
+#endif
 }

--- a/DiffPlex/Chunkers/LineChunker.cs
+++ b/DiffPlex/Chunkers/LineChunker.cs
@@ -1,20 +1,30 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace DiffPlex.Chunkers
+namespace DiffPlex.Chunkers;
+
+public class LineChunker : IChunker
+#if !NET_TOO_OLD_VER
+    , ISpanChunker
+#endif
 {
-    public class LineChunker:IChunker
+    private readonly string[] lineSeparators = new[] {"\r\n", "\r", "\n"};
+
+    /// <summary>
+    /// Gets the default singleton instance of the chunker.
+    /// </summary>
+    public static LineChunker Instance { get; } = new LineChunker();
+
+    public IReadOnlyList<string> Chunk(string text)
     {
-        private readonly string[] lineSeparators = new[] {"\r\n", "\r", "\n"};
-
-        /// <summary>
-        /// Gets the default singleton instance of the chunker.
-        /// </summary>
-        public static LineChunker Instance { get; } = new LineChunker();
-
-        public IReadOnlyList<string> Chunk(string text)
-        {
-            return text.Split(lineSeparators, StringSplitOptions.None);
-        }
+        return text.Split(lineSeparators, StringSplitOptions.None);
     }
+
+#if !NET_TOO_OLD_VER
+    public IReadOnlyList<string> Chunk(ReadOnlySpan<char> text)
+    {
+        // MemoryExtensions.Split(text, lineSeparators, StringSplitOptions.None);
+        return text.ToString().Split(lineSeparators, StringSplitOptions.None);
+    }
+#endif
 }

--- a/DiffPlex/Chunkers/LineEndingsPreservingChunker.cs
+++ b/DiffPlex/Chunkers/LineEndingsPreservingChunker.cs
@@ -1,51 +1,87 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
-namespace DiffPlex.Chunkers
+namespace DiffPlex.Chunkers;
+
+public class LineEndingsPreservingChunker : IChunker
+#if !NET_TOO_OLD_VER
+        , ISpanChunker
+#endif
 {
-    public class LineEndingsPreservingChunker:IChunker
+    /// <summary>
+    /// Gets the default singleton instance of the chunker.
+    /// </summary>
+    public static LineEndingsPreservingChunker Instance { get; } = new LineEndingsPreservingChunker();
+
+    public IReadOnlyList<string> Chunk(string text)
     {
-        private readonly string[] emptyArray = new string[0];
-
-        /// <summary>
-        /// Gets the default singleton instance of the chunker.
-        /// </summary>
-        public static LineEndingsPreservingChunker Instance { get; } = new LineEndingsPreservingChunker();
-
-        public IReadOnlyList<string> Chunk(string text)
+        var output = new List<string>();
+        if (string.IsNullOrEmpty(text)) return output;
+        var lastCut = 0;
+        for (var currentPosition = 0; currentPosition < text.Length; currentPosition++)
         {
-            if (string.IsNullOrEmpty(text))
-                return emptyArray;
-
-            var output = new List<string>();
-            var lastCut = 0;
-            for (var currentPosition = 0; currentPosition < text.Length; currentPosition++)
+            char ch = text[currentPosition];
+            switch (ch)
             {
-                char ch = text[currentPosition];
-                switch (ch)
-                {
-                    case '\n':
-                    case '\r':
+                case '\n':
+                case '\r':
+                    currentPosition++;
+                    if (ch == '\r' && currentPosition < text.Length && text[currentPosition] == '\n')
+                    {
                         currentPosition++;
-                        if (ch == '\r' && currentPosition < text.Length && text[currentPosition] == '\n')
-                        {
-                            currentPosition++;
-                        }
-                        var str = text.Substring(lastCut, currentPosition - lastCut);
-                        lastCut = currentPosition;
-                        output.Add(str);
-                        break;
-                    default:
-                        continue;
-                }
+                    }
+                    var str = text.Substring(lastCut, currentPosition - lastCut);
+                    lastCut = currentPosition;
+                    output.Add(str);
+                    break;
+                default:
+                    continue;
             }
-
-            if (lastCut != text.Length)
-            {
-                var str = text.Substring(lastCut, text.Length - lastCut);
-                output.Add(str);
-            }
-
-            return output;
         }
+
+        if (lastCut != text.Length)
+        {
+            var str = text.Substring(lastCut, text.Length - lastCut);
+            output.Add(str);
+        }
+
+        return output;
     }
+
+#if !NET_TOO_OLD_VER
+    public IReadOnlyList<string> Chunk(ReadOnlySpan<char> text)
+    {
+        var output = new List<string>();
+        if (text.Length == 0) return output;
+        var lastCut = 0;
+        for (var currentPosition = 0; currentPosition < text.Length; currentPosition++)
+        {
+            char ch = text[currentPosition];
+            switch (ch)
+            {
+                case '\n':
+                case '\r':
+                    currentPosition++;
+                    if (ch == '\r' && currentPosition < text.Length && text[currentPosition] == '\n')
+                    {
+                        currentPosition++;
+                    }
+                    var str = text.Slice(lastCut, currentPosition - lastCut);
+                    lastCut = currentPosition;
+                    output.Add(str.ToString());
+                    break;
+                default:
+                    continue;
+            }
+        }
+
+        if (lastCut != text.Length)
+        {
+            var str = text.Slice(lastCut, text.Length - lastCut);
+            output.Add(str.ToString());
+        }
+
+        return output;
+    }
+#endif
 }

--- a/DiffPlex/Chunkers/WordChunker.cs
+++ b/DiffPlex/Chunkers/WordChunker.cs
@@ -1,16 +1,15 @@
-﻿namespace DiffPlex.Chunkers
+﻿namespace DiffPlex.Chunkers;
+
+public class WordChunker : DelimiterChunker
 {
-    public class WordChunker:DelimiterChunker
+    private static char[] WordSeparators { get; } = { ' ', '　', '\t', '.', '(', ')', '{', '}', '[', ']', ',', '!', '?', ';', ':', '\'', '"', '~', '&', '|', '，', '、', '；', '：', '‘', '’', '“', '”', '（', '）', '【', '】', '『', '』', '「', '」', '《', '》', '。', '！', '？', '～', '—', '…' };
+
+    /// <summary>
+    /// Gets the default singleton instance of the chunker.
+    /// </summary>
+    public static WordChunker Instance { get; } = new();
+
+    public WordChunker() : base(WordSeparators)
     {
-        private static char[] WordSeparators { get; } = { ' ', '\t', '.', '(', ')', '{', '}', ',', '!', '?', ';' };
-
-        /// <summary>
-        /// Gets the default singleton instance of the chunker.
-        /// </summary>
-        public static WordChunker Instance { get; } = new WordChunker();
-
-        public WordChunker() : base(WordSeparators)
-        {
-        }
     }
 }

--- a/DiffPlex/DiffBuilder/IInlineDiffBuilder.cs
+++ b/DiffPlex/DiffBuilder/IInlineDiffBuilder.cs
@@ -1,10 +1,9 @@
 ﻿using DiffPlex.DiffBuilder.Model;
 
-namespace DiffPlex.DiffBuilder
+namespace DiffPlex.DiffBuilder;
+
+public interface IInlineDiffBuilder
 {
-    public interface IInlineDiffBuilder
-    {
-        DiffPaneModel BuildDiffModel(string oldText, string newText);
-        DiffPaneModel BuildDiffModel(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase, IChunker chunker);
-    }
+    DiffPaneModel BuildDiffModel(string oldText, string newText);
+    DiffPaneModel BuildDiffModel(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase, IChunker chunker);
 }

--- a/DiffPlex/DiffBuilder/ISideBySideDiffBuilder.cs
+++ b/DiffPlex/DiffBuilder/ISideBySideDiffBuilder.cs
@@ -1,18 +1,17 @@
 ﻿using DiffPlex.DiffBuilder.Model;
 
-namespace DiffPlex.DiffBuilder
+namespace DiffPlex.DiffBuilder;
+
+/// <summary>
+/// Provides methods that generate differences between texts for displaying in a side by side view.
+/// </summary>
+public interface ISideBySideDiffBuilder
 {
     /// <summary>
-    /// Provides methods that generate differences between texts for displaying in a side by side view.
+    /// Builds a diff model for displaying diffs in a side by side view
     /// </summary>
-    public interface ISideBySideDiffBuilder
-    {
-        /// <summary>
-        /// Builds a diff model for displaying diffs in a side by side view
-        /// </summary>
-        /// <param name="oldText">The old text.</param>
-        /// <param name="newText">The new text.</param>
-        /// <returns>The side by side diff model</returns>
-        SideBySideDiffModel BuildDiffModel(string oldText, string newText);
-    }
+    /// <param name="oldText">The old text.</param>
+    /// <param name="newText">The new text.</param>
+    /// <returns>The side by side diff model</returns>
+    SideBySideDiffModel BuildDiffModel(string oldText, string newText);
 }

--- a/DiffPlex/DiffBuilder/InlineDiffBuilder.cs
+++ b/DiffPlex/DiffBuilder/InlineDiffBuilder.cs
@@ -4,116 +4,147 @@ using DiffPlex.Chunkers;
 using DiffPlex.DiffBuilder.Model;
 using DiffPlex.Model;
 
-namespace DiffPlex.DiffBuilder
+namespace DiffPlex.DiffBuilder;
+
+public class InlineDiffBuilder : IInlineDiffBuilder
 {
-    public class InlineDiffBuilder : IInlineDiffBuilder
+    private readonly IDiffer differ;
+
+    /// <summary>
+    /// Gets the default singleton instance of the inline diff builder.
+    /// </summary>
+    public static InlineDiffBuilder Instance { get; } = new InlineDiffBuilder();
+
+    public InlineDiffBuilder(IDiffer differ = null)
     {
-        private readonly IDiffer differ;
+        this.differ = differ ?? Differ.Instance;
+    }
 
-        /// <summary>
-        /// Gets the default singleton instance of the inline diff builder.
-        /// </summary>
-        public static InlineDiffBuilder Instance { get; } = new InlineDiffBuilder();
+    public DiffPaneModel BuildDiffModel(string oldText, string newText)
+        => BuildDiffModel(oldText, newText, ignoreWhitespace: true);
 
-        public InlineDiffBuilder(IDiffer differ = null)
+    public DiffPaneModel BuildDiffModel(string oldText, string newText, bool ignoreWhitespace)
+    {
+        var chunker = new LineChunker();
+        return BuildDiffModel(oldText, newText, ignoreWhitespace, false, chunker);
+    }
+
+    public DiffPaneModel BuildDiffModel(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase, IChunker chunker)
+    {
+        if (oldText == null) throw new ArgumentNullException(nameof(oldText));
+        if (newText == null) throw new ArgumentNullException(nameof(newText));
+
+        var pieces = new List<DiffPiece>();
+        var diffResult = differ.CreateDiffs(oldText, newText, ignoreWhitespace, ignoreCase: ignoreCase, chunker);
+        BuildDiffPieces(diffResult, pieces);
+        return new(pieces);
+    }
+
+    /// <summary>
+    /// Gets the inline textual diffs.
+    /// </summary>
+    /// <param name="oldText">The old text to diff.</param>
+    /// <param name="newText">The new text.</param>
+    /// <param name="ignoreWhiteSpace"><see langword="true"/> if ignore the white space; otherwise, <see langword="false"/>.</param>
+    /// <param name="ignoreCase"><see langword="true"/> if case-insensitive; otherwise, <see langword="false"/>.</param>
+    /// <param name="chunker">The chunker.</param>
+    /// <returns>The diffs result.</returns>
+    public static DiffPaneModel Diff(string oldText, string newText, bool ignoreWhiteSpace = true, bool ignoreCase = false, IChunker chunker = null)
+    {
+        return Diff(Differ.Instance, oldText, newText, ignoreWhiteSpace, ignoreCase, chunker);
+    }
+
+#if !NET_TOO_OLD_VER
+    /// <summary>
+    /// Gets the inline textual diffs.
+    /// </summary>
+    /// <param name="oldText">The old text to diff.</param>
+    /// <param name="newText">The new text.</param>
+    /// <param name="ignoreWhiteSpace"><see langword="true"/> if ignore the white space; otherwise, <see langword="false"/>.</param>
+    /// <param name="ignoreCase"><see langword="true"/> if case-insensitive; otherwise, <see langword="false"/>.</param>
+    /// <param name="chunker">The chunker.</param>
+    /// <returns>The diffs result.</returns>
+    public static DiffPaneModel Diff(ReadOnlySpan<char> oldText, ReadOnlySpan<char> newText, bool ignoreWhiteSpace = true, bool ignoreCase = false, IChunker chunker = null)
+    {
+        return Diff(Differ.Instance, oldText, newText, ignoreWhiteSpace, ignoreCase, chunker);
+    }
+
+    /// <summary>
+    /// Gets the inline textual diffs.
+    /// </summary>
+    /// <param name="differ">The differ instance.</param>
+    /// <param name="oldText">The old text to diff.</param>
+    /// <param name="newText">The new text.</param>
+    /// <param name="ignoreWhiteSpace"><see langword="true"/> if ignore the white space; otherwise, <see langword="false"/>.</param>
+    /// <param name="ignoreCase"><see langword="true"/> if case-insensitive; otherwise, <see langword="false"/>.</param>
+    /// <param name="chunker">The chunker.</param>
+    /// <returns>The diffs result.</returns>
+    public static DiffPaneModel Diff(IDiffer differ, ReadOnlySpan<char> oldText, ReadOnlySpan<char> newText, bool ignoreWhiteSpace = true, bool ignoreCase = false, IChunker chunker = null)
+    {
+        var pieces = new List<DiffPiece>();
+        var diffResult = (differ ?? Differ.Instance).CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, chunker ?? LineChunker.Instance);
+        BuildDiffPieces(diffResult, pieces);
+        return new(pieces);
+    }
+#endif
+
+    /// <summary>
+    /// Gets the inline textual diffs.
+    /// </summary>
+    /// <param name="differ">The differ instance.</param>
+    /// <param name="oldText">The old text to diff.</param>
+    /// <param name="newText">The new text.</param>
+    /// <param name="ignoreWhiteSpace"><see langword="true"/> if ignore the white space; otherwise, <see langword="false"/>.</param>
+    /// <param name="ignoreCase"><see langword="true"/> if case-insensitive; otherwise, <see langword="false"/>.</param>
+    /// <param name="chunker">The chunker.</param>
+    /// <returns>The diffs result.</returns>
+    public static DiffPaneModel Diff(IDiffer differ, string oldText, string newText, bool ignoreWhiteSpace = true, bool ignoreCase = false, IChunker chunker = null)
+    {
+        if (oldText == null) throw new ArgumentNullException(nameof(oldText));
+        if (newText == null) throw new ArgumentNullException(nameof(newText));
+
+        var pieces = new List<DiffPiece>();
+        var diffResult = (differ ?? Differ.Instance).CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, chunker ?? LineChunker.Instance);
+        BuildDiffPieces(diffResult, pieces);
+        return new(pieces);
+    }
+
+    private static void BuildDiffPieces(DiffResult diffResult, List<DiffPiece> pieces)
+    {
+        int bPos = 0;
+
+        foreach (var diffBlock in diffResult.DiffBlocks)
         {
-            this.differ = differ ?? Differ.Instance;
-        }
+            for (; bPos < diffBlock.InsertStartB; bPos++)
+                pieces.Add(new DiffPiece(diffResult.PiecesNew[bPos], ChangeType.Unchanged, bPos + 1));
 
-        public DiffPaneModel BuildDiffModel(string oldText, string newText)
-            => BuildDiffModel(oldText, newText, ignoreWhitespace: true);
+            int i = 0;
+            for (; i < Math.Min(diffBlock.DeleteCountA, diffBlock.InsertCountB); i++)
+                pieces.Add(new DiffPiece(diffResult.PiecesOld[i + diffBlock.DeleteStartA], ChangeType.Deleted));
 
-        public DiffPaneModel BuildDiffModel(string oldText, string newText, bool ignoreWhitespace)
-        {
-            var chunker = new LineChunker();
-            return BuildDiffModel(oldText, newText, ignoreWhitespace, false, chunker);
-        }
-
-        public DiffPaneModel BuildDiffModel(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase, IChunker chunker)
-        {
-            if (oldText == null) throw new ArgumentNullException(nameof(oldText));
-            if (newText == null) throw new ArgumentNullException(nameof(newText));
-
-            var model = new DiffPaneModel();
-            var diffResult = differ.CreateDiffs(oldText, newText, ignoreWhitespace, ignoreCase: ignoreCase, chunker);
-            BuildDiffPieces(diffResult, model.Lines);
-            
-            return model;
-        }
-
-        /// <summary>
-        /// Gets the inline textual diffs.
-        /// </summary>
-        /// <param name="oldText">The old text to diff.</param>
-        /// <param name="newText">The new text.</param>
-        /// <param name="ignoreWhiteSpace"><see langword="true"/> if ignore the white space; otherwise, <see langword="false"/>.</param>
-        /// <param name="ignoreCase"><see langword="true"/> if case-insensitive; otherwise, <see langword="false"/>.</param>
-        /// <param name="chunker">The chunker.</param>
-        /// <returns>The diffs result.</returns>
-        public static DiffPaneModel Diff(string oldText, string newText, bool ignoreWhiteSpace = true, bool ignoreCase = false, IChunker chunker = null)
-        {
-            return Diff(Differ.Instance, oldText, newText, ignoreWhiteSpace, ignoreCase, chunker);
-        }
-
-        /// <summary>
-        /// Gets the inline textual diffs.
-        /// </summary>
-        /// <param name="differ">The differ instance.</param>
-        /// <param name="oldText">The old text to diff.</param>
-        /// <param name="newText">The new text.</param>
-        /// <param name="ignoreWhiteSpace"><see langword="true"/> if ignore the white space; otherwise, <see langword="false"/>.</param>
-        /// <param name="ignoreCase"><see langword="true"/> if case-insensitive; otherwise, <see langword="false"/>.</param>
-        /// <param name="chunker">The chunker.</param>
-        /// <returns>The diffs result.</returns>
-        public static DiffPaneModel Diff(IDiffer differ, string oldText, string newText, bool ignoreWhiteSpace = true, bool ignoreCase = false, IChunker chunker = null)
-        {
-            if (oldText == null) throw new ArgumentNullException(nameof(oldText));
-            if (newText == null) throw new ArgumentNullException(nameof(newText));
-
-            var model = new DiffPaneModel();
-            var diffResult = (differ ?? Differ.Instance).CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, chunker ?? LineChunker.Instance);
-            BuildDiffPieces(diffResult, model.Lines);
-            
-            return model;
-        }
-
-        private static void BuildDiffPieces(DiffResult diffResult, List<DiffPiece> pieces)
-        {
-            int bPos = 0;
-
-            foreach (var diffBlock in diffResult.DiffBlocks)
+            i = 0;
+            for (; i < Math.Min(diffBlock.DeleteCountA, diffBlock.InsertCountB); i++)
             {
-                for (; bPos < diffBlock.InsertStartB; bPos++)
-                    pieces.Add(new DiffPiece(diffResult.PiecesNew[bPos], ChangeType.Unchanged, bPos + 1));
+                pieces.Add(new DiffPiece(diffResult.PiecesNew[i + diffBlock.InsertStartB], ChangeType.Inserted, bPos + 1));
+                bPos++;
+            }
 
-                int i = 0;
-                for (; i < Math.Min(diffBlock.DeleteCountA, diffBlock.InsertCountB); i++)
+            if (diffBlock.DeleteCountA > diffBlock.InsertCountB)
+            {
+                for (; i < diffBlock.DeleteCountA; i++)
                     pieces.Add(new DiffPiece(diffResult.PiecesOld[i + diffBlock.DeleteStartA], ChangeType.Deleted));
-
-                i = 0;
-                for (; i < Math.Min(diffBlock.DeleteCountA, diffBlock.InsertCountB); i++)
+            }
+            else
+            {
+                for (; i < diffBlock.InsertCountB; i++)
                 {
                     pieces.Add(new DiffPiece(diffResult.PiecesNew[i + diffBlock.InsertStartB], ChangeType.Inserted, bPos + 1));
                     bPos++;
                 }
-
-                if (diffBlock.DeleteCountA > diffBlock.InsertCountB)
-                {
-                    for (; i < diffBlock.DeleteCountA; i++)
-                        pieces.Add(new DiffPiece(diffResult.PiecesOld[i + diffBlock.DeleteStartA], ChangeType.Deleted));
-                }
-                else
-                {
-                    for (; i < diffBlock.InsertCountB; i++)
-                    {
-                        pieces.Add(new DiffPiece(diffResult.PiecesNew[i + diffBlock.InsertStartB], ChangeType.Inserted, bPos + 1));
-                        bPos++;
-                    }
-                }
             }
-
-            for (; bPos < diffResult.PiecesNew.Count; bPos++)
-                pieces.Add(new DiffPiece(diffResult.PiecesNew[bPos], ChangeType.Unchanged, bPos + 1));
         }
+
+        for (; bPos < diffResult.PiecesNew.Count; bPos++)
+            pieces.Add(new DiffPiece(diffResult.PiecesNew[bPos], ChangeType.Unchanged, bPos + 1));
     }
 }

--- a/DiffPlex/DiffBuilder/Model/DiffPaneModel.cs
+++ b/DiffPlex/DiffBuilder/Model/DiffPaneModel.cs
@@ -1,20 +1,110 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
-namespace DiffPlex.DiffBuilder.Model
+namespace DiffPlex.DiffBuilder.Model;
+
+/// <summary>
+/// The model of diff lines.
+/// </summary>
+#if !NET_TOO_OLD_VER
+[System.Text.Json.Serialization.JsonConverter(typeof(JsonDiffPaneConverter))]
+#endif
+public class DiffPaneModel
 {
-    public class DiffPaneModel
+    /// <summary>
+    /// Initializes a new instance of the DiffPaneModel class.
+    /// </summary>
+    /// <param name="lines">The lines.</param>
+    public DiffPaneModel(IEnumerable<DiffPiece> lines)
     {
-        public List<DiffPiece> Lines { get; }
-
-        public bool HasDifferences
-        {
-            get { return Lines.Any(x => x.Type != ChangeType.Unchanged); }
-        }
-
-        public DiffPaneModel()
-        {
+#if NETSTANDARD1_0
+        if (lines is null)
             Lines = new List<DiffPiece>();
-        }
+        else if (lines is IReadOnlyList<DiffPiece> col)
+            Lines = col;
+        else
+            Lines = lines.ToList();
+#else
+        if (lines is List<DiffPiece> list)
+            Lines = list.AsReadOnly();
+        else if (lines is IReadOnlyList<DiffPiece> col)
+            Lines = col;
+        else if (lines is null)
+            Lines = new List<DiffPiece>();
+        else
+            Lines = lines.ToList().AsReadOnly();
+#endif
     }
+
+    /// <summary>
+    /// Gets all the lines.
+    /// </summary>
+    public IReadOnlyList<DiffPiece> Lines { get; }
+
+    /// <summary>
+    /// Gets the count of lines.
+    /// </summary>
+    public int Count => Lines.Count;
+
+    /// <summary>
+    /// Gets a value indicating whether it contains any difference.
+    /// </summary>
+    public bool HasDifferences => Lines.Any(x => x.Type != ChangeType.Unchanged);
+
+    /// <summary>
+    /// Concatenates the members of a constructed this collection of type string, using the specified separator between each line.
+    /// </summary>
+    /// <param name="separator">The line separator which is included in the returned string only if values has multiple lines.</param>
+    /// <param name="lineGenerator">The handler to format each line.</param>
+    /// <param name="skipNull">true if skip null returned by the lineGenerator; otherwise, false.</param>
+    /// <returns>A string that consists of the elements of values delimited by the separator string; or empty if values has zero elements.</returns>
+    public string Join(string separator, Func<DiffPiece, string> lineGenerator, bool skipNull = false)
+    {
+        var col = Lines.Select(lineGenerator);
+        if (skipNull) col = col.Where(ele => ele != null);
+        return string.Join(separator, col);
+    }
+
+    /// <summary>
+    /// Concatenates the members of a constructed this collection of type string in each line.
+    /// </summary>
+    /// <param name="lineGenerator">The handler to format each line.</param>
+    /// <param name="skipNull">true if skip null returned by the lineGenerator; otherwise, false.</param>
+    /// <returns>A string that consists of the elements of values delimited by the separator string; or empty if values has zero elements.</returns>
+    public string Join(Func<DiffPiece, string> lineGenerator, bool skipNull = false)
+        => Join(Environment.NewLine, lineGenerator, skipNull);
+
+    /// <summary>
+    /// Concatenates the members of a constructed this collection of type string, using the specified separator between each line.
+    /// </summary>
+    /// <param name="separator">The line separator which is included in the returned string only if values has multiple lines.</param>
+    /// <param name="lineGenerator">The handler to format each line.</param>
+    /// <param name="skipNull">true if skip null returned by the lineGenerator; otherwise, false.</param>
+    /// <returns>A string that consists of the elements of values delimited by the separator string; or empty if values has zero elements.</returns>
+    public string Join(string separator, Func<DiffPiece, int, string> lineGenerator, bool skipNull = false)
+    {
+        var col = Lines.Select(lineGenerator);
+        if (skipNull) col = col.Where(ele => ele != null);
+        return string.Join(separator, col);
+    }
+
+    /// <summary>
+    /// Concatenates the members of a constructed this collection of type string in each line.
+    /// </summary>
+    /// <param name="lineGenerator">The handler to format each line.</param>
+    /// <param name="skipNull">true if skip null returned by the lineGenerator; otherwise, false.</param>
+    /// <returns>A string that consists of the elements of values delimited by the separator string; or empty if values has zero elements.</returns>
+    public string Join(Func<DiffPiece, int, string> lineGenerator, bool skipNull = false)
+        => Join(Environment.NewLine, lineGenerator, skipNull);
+
+    /// <summary>
+    /// Concatenates the members of a constructed this collection of type string in each line.
+    /// </summary>
+    /// <returns>A string that consists of the elements of values delimited by the separator string; or empty if values has zero elements.</returns>
+    public string Join()
+        => Join(Environment.NewLine, FormatToString, true);
+
+    private static string FormatToString(DiffPiece value)
+        => value?.ToString();
 }

--- a/DiffPlex/DiffBuilder/Model/DiffPiece.cs
+++ b/DiffPlex/DiffBuilder/Model/DiffPiece.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace DiffPlex.DiffBuilder.Model;
 
-public enum ChangeType
+public enum ChangeType : byte
 {
     Unchanged,
     Deleted,
@@ -100,6 +100,11 @@ public class DiffPiece : IEquatable<DiffPiece>
     }
 
 #if !NET_TOO_OLD_VER
+    /// <summary>
+    /// Writes current diff piece into UTF-8 JSON stream.
+    /// </summary>
+    /// <param name="writer">The UTF-8 JSON stream writer.</param>
+    /// <param name="options">The JSON srialization options.</param>
     public void Write(System.Text.Json.Utf8JsonWriter writer, System.Text.Json.JsonSerializerOptions options)
     {
         writer.WriteStartObject();

--- a/DiffPlex/DiffBuilder/Model/DiffPiece.cs
+++ b/DiffPlex/DiffBuilder/Model/DiffPiece.cs
@@ -1,77 +1,167 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 
-namespace DiffPlex.DiffBuilder.Model
+namespace DiffPlex.DiffBuilder.Model;
+
+public enum ChangeType
 {
-    public enum ChangeType
+    Unchanged,
+    Deleted,
+    Inserted,
+    Imaginary,
+    Modified
+}
+
+/// <summary>
+/// The diff piece model.
+/// </summary>
+#if !NET_TOO_OLD_VER
+[System.Text.Json.Serialization.JsonConverter(typeof(JsonDiffPieceConverter))]
+#endif
+public class DiffPiece : IEquatable<DiffPiece>
+{
+    /// <summary>
+    /// Gets the change type.
+    /// </summary>
+    public ChangeType Type { get; }
+
+    /// <summary>
+    /// Gets the nullable zero-based position.
+    /// </summary>
+    public int? Position { get; }
+
+    /// <summary>
+    /// Gets the content text.
+    /// </summary>
+    public string Text { get; }
+
+    /// <summary>
+    /// Gets the sub pieces.
+    /// </summary>
+    public IReadOnlyList<DiffPiece> SubPieces { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the DiffPiece class.
+    /// </summary>
+    public DiffPiece()
+        : this(null, ChangeType.Imaginary)
     {
-        Unchanged,
-        Deleted,
-        Inserted,
-        Imaginary,
-        Modified
     }
 
-    public class DiffPiece : IEquatable<DiffPiece>
+    /// <summary>
+    /// Initializes a new instance of the DiffPiece class.
+    /// </summary>
+    /// <param name="text">The content text.</param>
+    /// <param name="type">The change type.</param>
+    /// <param name="position">The nullable zero-based position</param>
+    public DiffPiece(string text, ChangeType type, int? position = null)
+        : this(text, type, position, null)
     {
-        public ChangeType Type { get; set; }
-        public int? Position { get; set; }
-        public string Text { get; set; }
-        public List<DiffPiece> SubPieces { get; set; } = new List<DiffPiece>();
+    }
 
-        public DiffPiece(string text, ChangeType type, int? position = null)
+    /// <summary>
+    /// Initializes a new instance of the DiffPiece class.
+    /// </summary>
+    /// <param name="text">The content text.</param>
+    /// <param name="type">The change type.</param>
+    /// <param name="position">The nullable zero-based position</param>
+    /// <param name="subPieces">The sub pieces.</param>
+    public DiffPiece(string text, ChangeType type, int? position, IReadOnlyList<DiffPiece> subPieces)
+    {
+        Text = text;
+        Position = position;
+        Type = type;
+        SubPieces = subPieces ?? new List<DiffPiece>();
+    }
+
+    public override bool Equals(object obj)
+    {
+        return Equals(obj as DiffPiece);
+    }
+
+    public bool Equals(DiffPiece other)
+    {
+        return other != null
+            && Type == other.Type
+            && EqualityComparer<int?>.Default.Equals(Position, other.Position)
+            && Text == other.Text
+            && SubPiecesEqual(other);
+    }
+
+    public override int GetHashCode()
+    {
+        var hashCode = 1688038063;
+        hashCode = hashCode * -1521134295 + Type.GetHashCode();
+        hashCode = hashCode * -1521134295 + EqualityComparer<int?>.Default.GetHashCode(Position);
+        hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Text);
+        hashCode = hashCode * -1521134295 + EqualityComparer<int?>.Default.GetHashCode(SubPieces?.Count);
+        return hashCode;
+    }
+
+#if !NET_TOO_OLD_VER
+    public void Write(System.Text.Json.Utf8JsonWriter writer, System.Text.Json.JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("type", Type.ToString());
+        if (Position.HasValue) writer.WriteNumber("position", Position.Value);
+        writer.WriteString("text", Text);
+        if (SubPieces.Count > 0)
         {
-            Text = text;
-            Position = position;
-            Type = type;
+            writer.WriteStartArray("sub");
+            JsonDiffPieceConverter.Write(SubPieces, writer, options);
+            writer.WriteEndArray();
         }
 
-        public DiffPiece()
-            : this(null, ChangeType.Imaginary)
+        writer.WriteEndObject();
+    }
+#endif
+
+    /// <summary>
+    /// Returns a string that represents this diff piece.
+    /// </summary>
+    /// <returns>A string that represents this diff piece.</returns>
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+        if (Position.HasValue) sb.Append(Position.Value);
+        sb.Append('\t');
+        switch (Type)
         {
+            case ChangeType.Inserted:
+                sb.Append("+ ");
+                break;
+            case ChangeType.Deleted:
+                sb.Append("- ");
+                break;
+            case ChangeType.Modified:
+                sb.Append("M ");
+                break;
+            default:
+                sb.Append("  ");
+                break;
         }
 
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as DiffPiece);
-        }
+        sb.Append(Text);
+        return sb.ToString();
+    }
 
-        public bool Equals(DiffPiece other)
-        {
-            return other != null
-                && Type == other.Type
-                && EqualityComparer<int?>.Default.Equals(Position, other.Position)
-                && Text == other.Text
-                && SubPiecesEqual(other);
-        }
+    private bool SubPiecesEqual(DiffPiece other)
+    {
+        if (SubPieces is null)
+            return other.SubPieces is null;
+        else if (other.SubPieces is null)
+            return false;
 
-        public override int GetHashCode()
-        {
-            var hashCode = 1688038063;
-            hashCode = hashCode * -1521134295 + Type.GetHashCode();
-            hashCode = hashCode * -1521134295 + EqualityComparer<int?>.Default.GetHashCode(Position);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Text);
-            hashCode = hashCode * -1521134295 + EqualityComparer<int?>.Default.GetHashCode(SubPieces?.Count);
-            return hashCode;
-        }
+        if (SubPieces.Count != other.SubPieces.Count)
+            return false;
 
-        private bool SubPiecesEqual(DiffPiece other)
+        for (int i = 0; i < SubPieces.Count; i++)
         {
-            if (SubPieces is null)
-                return other.SubPieces is null;
-            else if (other.SubPieces is null)
+            if (!Equals(SubPieces[i], other.SubPieces[i]))
                 return false;
-
-            if (SubPieces.Count != other.SubPieces.Count)
-                return false;
-
-            for (int i = 0; i < SubPieces.Count; i++)
-            {
-                if (!Equals(SubPieces[i], other.SubPieces[i]))
-                    return false;
-            }
-
-            return true;
         }
+
+        return true;
     }
 }

--- a/DiffPlex/DiffBuilder/Model/JsonConverter.cs
+++ b/DiffPlex/DiffBuilder/Model/JsonConverter.cs
@@ -1,0 +1,206 @@
+﻿#if !NET_TOO_OLD_VER
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DiffPlex.DiffBuilder.Model;
+
+internal class JsonDiffPieceConverter : JsonConverter<DiffPiece>
+{
+    /// <inheritdoc />
+    public override DiffPiece Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Null:
+            case JsonTokenType.False:
+                return default;
+            case JsonTokenType.StartObject:
+                var json = JsonElement.ParseValue(ref reader);
+                var sub = ReadList(json, "sub");
+                return Read(json, sub);
+            default:
+                throw new JsonException($"The token type is {reader.TokenType} but expect JSON object.");
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, DiffPiece value, JsonSerializerOptions options)
+    {
+        Write(value, writer, options);
+    }
+
+    private static string GetString(JsonElement json, string property)
+    {
+        if (!json.TryGetProperty(property, out var prop)) return null;
+        if (prop.ValueKind == JsonValueKind.String) return prop.GetString();
+        if (prop.ValueKind == JsonValueKind.Number) return prop.GetDouble().ToString();
+        return null;
+    }
+
+    private static int? GetInt32(JsonElement json, string property)
+    {
+        if (!json.TryGetProperty(property, out var prop)) return null;
+        if (prop.TryGetInt32(out var i)) return i;
+        return null;
+    }
+
+    private static ChangeType GetChangeType(JsonElement json, string property)
+    {
+        if (!json.TryGetProperty(property, out var prop)) return ChangeType.Imaginary;
+        switch (prop.ValueKind)
+        {
+            case JsonValueKind.Null:
+                return ChangeType.Unchanged;
+            case JsonValueKind.False:
+                return ChangeType.Deleted;
+            case JsonValueKind.True:
+                return ChangeType.Inserted;
+            case JsonValueKind.String:
+                var s = prop.GetString();
+                if (string.IsNullOrWhiteSpace(s)) return ChangeType.Imaginary;
+                return Enum.TryParse<ChangeType>(s, true, out var v) ? v : s.ToLowerInvariant() switch
+                {
+                    "+" or "add" or "insert" => ChangeType.Inserted,
+                    "-" or "del" or "delete" => ChangeType.Deleted,
+                    " " or "same" => ChangeType.Unchanged,
+                    "m" or "mod" or "modify" => ChangeType.Modified,
+                    _ => ChangeType.Imaginary
+                };
+            case JsonValueKind.Number:
+                if (prop.TryGetInt32(out var i)) return (ChangeType)i;
+                break;
+        }
+
+        return ChangeType.Imaginary;
+    }
+
+    private static DiffPiece Read(JsonElement json, IReadOnlyList<DiffPiece> sub)
+    {
+        if (json.ValueKind == JsonValueKind.Object) return new(GetString(json, "text"), GetChangeType(json, "type"), GetInt32(json, "position"), sub);
+        if (json.ValueKind == JsonValueKind.Null || json.ValueKind == JsonValueKind.Undefined || json.ValueKind == JsonValueKind.False) return null;
+        throw new JsonException($"Expect a JSON object");
+    }
+
+    internal static List<DiffPiece> ReadList(JsonElement json, string property)
+    {
+        if (!json.TryGetProperty(property, out var arr)) return null;
+        return ReadList(arr);
+    }
+
+    internal static List<DiffPiece> ReadList(JsonElement arr)
+    {
+        if (arr.ValueKind != JsonValueKind.Array)
+        {
+            if (arr.ValueKind == JsonValueKind.Object) return ReadList(arr, "lines");
+            return null;
+        }
+
+        var len = arr.GetArrayLength();
+        var list = new List<DiffPiece>();
+        for (var i = 0; i < len; i++)
+        {
+            var item = Read(arr[i], null);
+            if (item != null) list.Add(item);
+        }
+
+        return list;
+    }
+
+    internal static void Write(DiffPiece value, Utf8JsonWriter writer, JsonSerializerOptions options)
+    {
+        if (value is null) writer.WriteNullValue();
+        value.Write(writer, options);
+    }
+
+    internal static void Write(IEnumerable<DiffPiece> sub, Utf8JsonWriter writer, JsonSerializerOptions options)
+    {
+        foreach (var item in sub)
+        {
+            Write(item, writer, options);
+        }
+    }
+}
+
+internal class JsonDiffPaneConverter : JsonConverter<DiffPaneModel>
+{
+    /// <inheritdoc />
+    public override DiffPaneModel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Null:
+            case JsonTokenType.False:
+                return default;
+            case JsonTokenType.StartArray:
+                {
+                    var arr = JsonElement.ParseValue(ref reader);
+                    var list = JsonDiffPieceConverter.ReadList(arr);
+                    return new(list);
+                }
+            case JsonTokenType.StartObject:
+                {
+                    var json = JsonElement.ParseValue(ref reader);
+                    var list = JsonDiffPieceConverter.ReadList(json, "lines");
+                    return new(list);
+                }
+            default:
+                throw new JsonException($"The token type is {reader.TokenType} but expect JSON object.");
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, DiffPaneModel value, JsonSerializerOptions options)
+    {
+        if (value is null) writer.WriteNullValue();
+        writer.WriteStartObject();
+        writer.WriteStartArray("lines");
+        JsonDiffPieceConverter.Write(value.Lines, writer, options);
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+    }
+}
+
+internal class JsonSideBySideDiffConverter : JsonConverter<SideBySideDiffModel>
+{
+    /// <inheritdoc />
+    public override SideBySideDiffModel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Null:
+                return default;
+            case JsonTokenType.StartArray:
+                {
+                    var arr = JsonElement.ParseValue(ref reader);
+                    var list = JsonDiffPieceConverter.ReadList(arr);
+                    return new(list, list);
+                }
+            case JsonTokenType.StartObject:
+                {
+                    var json = JsonElement.ParseValue(ref reader);
+                    var oldText = JsonDiffPieceConverter.ReadList(json, "old");
+                    var newText = JsonDiffPieceConverter.ReadList(json, "new");
+                    return new(oldText, newText);
+                }
+            default:
+                throw new JsonException($"The token type is {reader.TokenType} but expect JSON object.");
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, SideBySideDiffModel value, JsonSerializerOptions options)
+    {
+        if (value is null) writer.WriteNullValue();
+        writer.WriteStartObject();
+        writer.WriteStartArray("old");
+        JsonDiffPieceConverter.Write(value.OldText.Lines, writer, options);
+        writer.WriteEndArray();
+        writer.WriteStartArray("new");
+        JsonDiffPieceConverter.Write(value.NewText.Lines, writer, options);
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+    }
+}
+#endif

--- a/DiffPlex/DiffBuilder/Model/SideBySideDiffModel.cs
+++ b/DiffPlex/DiffBuilder/Model/SideBySideDiffModel.cs
@@ -1,17 +1,34 @@
-﻿namespace DiffPlex.DiffBuilder.Model
+﻿using System.Collections.Generic;
+
+namespace DiffPlex.DiffBuilder.Model;
+
+/// <summary>
+/// A model which represents differences between to texts to be shown side by side.
+/// </summary>
+/// <param name="oldText">The old text information in diff.</param>
+/// <param name="newText">The new text information in diff.</param>
+#if !NET_TOO_OLD_VER
+[System.Text.Json.Serialization.JsonConverter(typeof(JsonSideBySideDiffConverter))]
+#endif
+public class SideBySideDiffModel(DiffPaneModel oldText, DiffPaneModel newText)
 {
     /// <summary>
-    /// A model which represents differences between to texts to be shown side by side
+    /// Initializes a new instance of the SideBySideDiffModel class.
     /// </summary>
-    public class SideBySideDiffModel
+    /// <param name="oldText">The old text information in diff.</param>
+    /// <param name="newText">The new text information in diff.</param>
+    public SideBySideDiffModel(IReadOnlyList<DiffPiece> oldText, IReadOnlyList<DiffPiece> newText)
+        : this(new DiffPaneModel(oldText), new(newText))
     {
-        public DiffPaneModel OldText { get; }
-        public DiffPaneModel NewText { get; }
-
-        public SideBySideDiffModel()
-        {
-            OldText = new DiffPaneModel();
-            NewText = new DiffPaneModel();
-        }
     }
+
+    /// <summary>
+    /// Gets the old text model.
+    /// </summary>
+    public DiffPaneModel OldText { get; } = oldText ?? new(null);
+
+    /// <summary>
+    /// Gets the new text model.
+    /// </summary>
+    public DiffPaneModel NewText { get; } = newText ?? new(null);
 }

--- a/DiffPlex/DiffBuilder/SideBySideDiffBuilder.cs
+++ b/DiffPlex/DiffBuilder/SideBySideDiffBuilder.cs
@@ -1,184 +1,175 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using DiffPlex.Chunkers;
 using DiffPlex.DiffBuilder.Model;
 using DiffPlex.Model;
 
-namespace DiffPlex.DiffBuilder
+namespace DiffPlex.DiffBuilder;
+
+public class SideBySideDiffBuilder : ISideBySideDiffBuilder
 {
-    public class SideBySideDiffBuilder : ISideBySideDiffBuilder
+    private readonly IDiffer differ;
+    private readonly IChunker lineChunker;
+    private readonly IChunker wordChunker;
+
+    private delegate ChangeType PieceBuilder(string oldText, string newText, List<DiffPiece> oldPieces, List<DiffPiece> newPieces, bool ignoreWhitespace, bool ignoreCase);
+
+    /// <summary>
+    /// Gets the default singleton instance.
+    /// </summary>
+    public static SideBySideDiffBuilder Instance { get; } = new SideBySideDiffBuilder();
+
+    public SideBySideDiffBuilder(IDiffer differ, IChunker lineChunker, IChunker wordChunker)
     {
-        private readonly IDiffer differ;
-        private readonly IChunker lineChunker;
-        private readonly IChunker wordChunker;
+        this.differ = differ ?? Differ.Instance;
+        this.lineChunker = lineChunker ?? throw new ArgumentNullException(nameof(lineChunker));
+        this.wordChunker = wordChunker ?? throw new ArgumentNullException(nameof(wordChunker));
+    }
 
-        private delegate ChangeType PieceBuilder(string oldText, string newText, List<DiffPiece> oldPieces, List<DiffPiece> newPieces, bool ignoreWhitespace, bool ignoreCase);
+    public SideBySideDiffBuilder(IDiffer differ = null) :
+        this(differ, new LineChunker(), new WordChunker())
+    {
+    }
 
-        /// <summary>
-        /// Gets the default singleton instance.
-        /// </summary>
-        public static SideBySideDiffBuilder Instance { get; } = new SideBySideDiffBuilder();
+    public SideBySideDiffBuilder(IDiffer differ, char[] wordSeparators)
+        : this(differ, new LineChunker(), new DelimiterChunker(wordSeparators))
+    {
+    }
 
-        public SideBySideDiffBuilder(IDiffer differ, IChunker lineChunker, IChunker wordChunker)
+    public SideBySideDiffModel BuildDiffModel(string oldText, string newText)
+        => BuildDiffModel(oldText, newText, ignoreWhitespace: true);
+
+    public SideBySideDiffModel BuildDiffModel(string oldText, string newText, bool ignoreWhitespace) => BuildDiffModel(
+            oldText,
+            newText,
+            ignoreWhitespace,
+            false);
+
+    public SideBySideDiffModel BuildDiffModel(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase)
+    {
+        return BuildLineDiff(
+            oldText ?? throw new ArgumentNullException(nameof(oldText)),
+            newText ?? throw new ArgumentNullException(nameof(newText)),
+            ignoreWhitespace,
+            ignoreCase);
+    }
+
+    /// <summary>
+    /// Gets the side-by-side textual diffs.
+    /// </summary>
+    /// <param name="oldText">The old text to diff.</param>
+    /// <param name="newText">The new text.</param>
+    /// <param name="ignoreWhiteSpace"><see langword="true"/> if ignore the white space; otherwise, <see langword="false"/>.</param>
+    /// <param name="ignoreCase"><see langword="true"/> if case-insensitive; otherwise, <see langword="false"/>.</param>
+    /// <returns>The diffs result.</returns>
+    public static SideBySideDiffModel Diff(string oldText, string newText, bool ignoreWhiteSpace = true, bool ignoreCase = false)
+    {
+        if (oldText == null) throw new ArgumentNullException(nameof(oldText));
+        if (newText == null) throw new ArgumentNullException(nameof(newText));
+        var diffResult = Differ.Instance.CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, LineChunker.Instance);
+        return BuildDiffModel(diffResult, BuildWordDiffPiecesInternal, ignoreWhiteSpace, ignoreCase);
+    }
+
+#if !NET_TOO_OLD_VER
+    /// <summary>
+    /// Gets the side-by-side textual diffs.
+    /// </summary>
+    /// <param name="oldText">The old text to diff.</param>
+    /// <param name="newText">The new text.</param>
+    /// <param name="ignoreWhiteSpace"><see langword="true"/> if ignore the white space; otherwise, <see langword="false"/>.</param>
+    /// <param name="ignoreCase"><see langword="true"/> if case-insensitive; otherwise, <see langword="false"/>.</param>
+    /// <returns>The diffs result.</returns>
+    public static SideBySideDiffModel Diff(ReadOnlySpan<char> oldText, ReadOnlySpan<char> newText, bool ignoreWhiteSpace = true, bool ignoreCase = false)
+    {
+        if (oldText == null) throw new ArgumentNullException(nameof(oldText));
+        if (newText == null) throw new ArgumentNullException(nameof(newText));
+        var diffResult = Differ.Instance.CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, LineChunker.Instance);
+        return BuildDiffModel(diffResult, BuildWordDiffPiecesInternal, ignoreWhiteSpace, ignoreCase);
+    }
+
+    /// <summary>
+    /// Gets the side-by-side textual diffs.
+    /// </summary>
+    /// <param name="differ">The differ instance.</param>
+    /// <param name="oldText">The old text to diff.</param>
+    /// <param name="newText">The new text.</param>
+    /// <param name="ignoreWhiteSpace"><see langword="true"/> if ignore the white space; otherwise, <see langword="false"/>.</param>
+    /// <param name="ignoreCase"><see langword="true"/> if case-insensitive; otherwise, <see langword="false"/>.</param>
+    /// <param name="lineChunker">The line chunker.</param>
+    /// <param name="wordChunker">The word chunker.</param>
+    /// <returns>The diffs result.</returns>
+    public static SideBySideDiffModel Diff(IDiffer differ, ReadOnlySpan<char> oldText, ReadOnlySpan<char> newText, bool ignoreWhiteSpace = true, bool ignoreCase = false, IChunker lineChunker = null, IChunker wordChunker = null)
+    {
+        if (differ == null) return Diff(oldText, newText, ignoreWhiteSpace, ignoreCase);
+        var diffResult = differ.CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, lineChunker ?? LineChunker.Instance);
+        return BuildDiffModel(diffResult, (ot, nt, op, np, iw, ic) =>
         {
-            this.differ = differ ?? Differ.Instance;
-            this.lineChunker = lineChunker ?? throw new ArgumentNullException(nameof(lineChunker));
-            this.wordChunker = wordChunker ?? throw new ArgumentNullException(nameof(wordChunker));
-        }
+            var r = differ.CreateDiffs(ot, nt, iw, ic, wordChunker ?? WordChunker.Instance);
+            return BuildDiffPieces(r, op, np, null, iw, ic);
+        }, ignoreWhiteSpace, ignoreCase);
+    }
+#endif
 
-        public SideBySideDiffBuilder(IDiffer differ = null) :
-            this(differ, new LineChunker(), new WordChunker())
+    /// <summary>
+    /// Gets the side-by-side textual diffs.
+    /// </summary>
+    /// <param name="differ">The differ instance.</param>
+    /// <param name="oldText">The old text to diff.</param>
+    /// <param name="newText">The new text.</param>
+    /// <param name="ignoreWhiteSpace"><see langword="true"/> if ignore the white space; otherwise, <see langword="false"/>.</param>
+    /// <param name="ignoreCase"><see langword="true"/> if case-insensitive; otherwise, <see langword="false"/>.</param>
+    /// <param name="lineChunker">The line chunker.</param>
+    /// <param name="wordChunker">The word chunker.</param>
+    /// <returns>The diffs result.</returns>
+    public static SideBySideDiffModel Diff(IDiffer differ, string oldText, string newText, bool ignoreWhiteSpace = true, bool ignoreCase = false, IChunker lineChunker = null, IChunker wordChunker = null)
+    {
+        if (oldText == null) throw new ArgumentNullException(nameof(oldText));
+        if (newText == null) throw new ArgumentNullException(nameof(newText));
+        if (differ == null) return Diff(oldText, newText, ignoreWhiteSpace, ignoreCase);
+        var diffResult = differ.CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, lineChunker ?? LineChunker.Instance);
+        return BuildDiffModel(diffResult, (ot, nt, op, np, iw, ic) =>
         {
-        }
+            var r = differ.CreateDiffs(ot, nt, iw, ic, wordChunker ?? WordChunker.Instance);
+            return BuildDiffPieces(r, op, np, null, iw, ic);
+        }, ignoreWhiteSpace, ignoreCase);
+    }
 
-        public SideBySideDiffBuilder(IDiffer differ, char[] wordSeparators)
-            : this(differ, new LineChunker(), new DelimiterChunker(wordSeparators))
+    private static ChangeType BuildWordDiffPiecesInternal(string oldText, string newText, List<DiffPiece> oldPieces, List<DiffPiece> newPieces, bool ignoreWhiteSpace, bool ignoreCase)
+    {
+        var diffResult = Differ.Instance.CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, WordChunker.Instance);
+        return BuildDiffPieces(diffResult, oldPieces, newPieces, null, ignoreWhiteSpace, ignoreCase);
+    }
+
+    private SideBySideDiffModel BuildLineDiff(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase)
+    {
+        var diffResult = differ.CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, lineChunker);
+        return BuildDiffModel(diffResult, BuildWordDiffPieces, ignoreWhiteSpace, ignoreCase);
+    }
+
+    private ChangeType BuildWordDiffPieces(string oldText, string newText, List<DiffPiece> oldPieces, List<DiffPiece> newPieces, bool ignoreWhiteSpace, bool ignoreCase)
+    {
+        var diffResult = differ.CreateDiffs(oldText, newText, ignoreWhiteSpace: ignoreWhiteSpace, ignoreCase, wordChunker);
+        return BuildDiffPieces(diffResult, oldPieces, newPieces, subPieceBuilder: null, ignoreWhiteSpace, ignoreCase);
+    }
+
+    private static SideBySideDiffModel BuildDiffModel(DiffResult diffResult, PieceBuilder subPieceBuilder, bool ignoreWhiteSpace, bool ignoreCase)
+    {
+        var oldLines = new List<DiffPiece>();
+        var newLines = new List<DiffPiece>();
+        BuildDiffPieces(diffResult, oldLines, newLines, subPieceBuilder, ignoreWhiteSpace, ignoreCase);
+        return new(oldLines, newLines);
+    }
+
+    private static ChangeType BuildDiffPieces(DiffResult diffResult, List<DiffPiece> oldPieces, List<DiffPiece> newPieces, PieceBuilder subPieceBuilder, bool ignoreWhiteSpace, bool ignoreCase)
+    {
+        var aPos = 0;
+        var bPos = 0;
+
+        foreach (var diffBlock in diffResult.DiffBlocks)
         {
-        }
-
-        public SideBySideDiffModel BuildDiffModel(string oldText, string newText)
-            => BuildDiffModel(oldText, newText, ignoreWhitespace: true);
-
-        public SideBySideDiffModel BuildDiffModel(string oldText, string newText, bool ignoreWhitespace) => BuildDiffModel(
-                oldText,
-                newText,
-                ignoreWhitespace,
-                false);
-
-        public SideBySideDiffModel BuildDiffModel(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase)
-        {
-            return BuildLineDiff(
-                oldText ?? throw new ArgumentNullException(nameof(oldText)),
-                newText ?? throw new ArgumentNullException(nameof(newText)),
-                ignoreWhitespace,
-                ignoreCase);
-        }
-
-        /// <summary>
-        /// Gets the side-by-side textual diffs.
-        /// </summary>
-        /// <param name="oldText">The old text to diff.</param>
-        /// <param name="newText">The new text.</param>
-        /// <param name="ignoreWhiteSpace"><see langword="true"/> if ignore the white space; otherwise, <see langword="false"/>.</param>
-        /// <param name="ignoreCase"><see langword="true"/> if case-insensitive; otherwise, <see langword="false"/>.</param>
-        /// <returns>The diffs result.</returns>
-        public static SideBySideDiffModel Diff(string oldText, string newText, bool ignoreWhiteSpace = true, bool ignoreCase = false)
-        {
-            if (oldText == null) throw new ArgumentNullException(nameof(oldText));
-            if (newText == null) throw new ArgumentNullException(nameof(newText));
-
-            var model = new SideBySideDiffModel();
-            var diffResult = Differ.Instance.CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, LineChunker.Instance);
-            BuildDiffPieces(diffResult, model.OldText.Lines, model.NewText.Lines, BuildWordDiffPiecesInternal, ignoreWhiteSpace, ignoreCase);
-
-            return model;
-        }
-
-        /// <summary>
-        /// Gets the side-by-side textual diffs.
-        /// </summary>
-        /// <param name="differ">The differ instance.</param>
-        /// <param name="oldText">The old text to diff.</param>
-        /// <param name="newText">The new text.</param>
-        /// <param name="ignoreWhiteSpace"><see langword="true"/> if ignore the white space; otherwise, <see langword="false"/>.</param>
-        /// <param name="ignoreCase"><see langword="true"/> if case-insensitive; otherwise, <see langword="false"/>.</param>
-        /// <param name="lineChunker">The line chunker.</param>
-        /// <param name="wordChunker">The word chunker.</param>
-        /// <returns>The diffs result.</returns>
-        public static SideBySideDiffModel Diff(IDiffer differ, string oldText, string newText, bool ignoreWhiteSpace = true, bool ignoreCase = false, IChunker lineChunker = null, IChunker wordChunker = null)
-        {
-            if (oldText == null) throw new ArgumentNullException(nameof(oldText));
-            if (newText == null) throw new ArgumentNullException(nameof(newText));
-
-            if (differ == null) return Diff(oldText, newText, ignoreWhiteSpace, ignoreCase);
-
-            var model = new SideBySideDiffModel();
-            var diffResult = differ.CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, lineChunker ?? LineChunker.Instance);
-            BuildDiffPieces(diffResult, model.OldText.Lines, model.NewText.Lines, (ot, nt, op, np, iw, ic) =>
-            {
-                var r = differ.CreateDiffs(ot, nt, iw, ic, wordChunker ?? WordChunker.Instance);
-                return BuildDiffPieces(r, op, np, null, iw, ic);
-            }, ignoreWhiteSpace, ignoreCase);
-
-            return model;
-        }
-
-        private static ChangeType BuildWordDiffPiecesInternal(string oldText, string newText, List<DiffPiece> oldPieces, List<DiffPiece> newPieces, bool ignoreWhiteSpace, bool ignoreCase)
-        {
-            var diffResult = Differ.Instance.CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, WordChunker.Instance);
-            return BuildDiffPieces(diffResult, oldPieces, newPieces, null, ignoreWhiteSpace, ignoreCase);
-        }
-
-        private SideBySideDiffModel BuildLineDiff(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase)
-        {
-            var model = new SideBySideDiffModel();
-            var diffResult = differ.CreateDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, lineChunker);
-            BuildDiffPieces(diffResult, model.OldText.Lines, model.NewText.Lines, BuildWordDiffPieces, ignoreWhiteSpace, ignoreCase);
-
-            return model;
-        }
-
-        private ChangeType BuildWordDiffPieces(string oldText, string newText, List<DiffPiece> oldPieces, List<DiffPiece> newPieces, bool ignoreWhiteSpace, bool ignoreCase)
-        {
-            var diffResult = differ.CreateDiffs(oldText, newText, ignoreWhiteSpace: ignoreWhiteSpace, ignoreCase, wordChunker);
-            return BuildDiffPieces(diffResult, oldPieces, newPieces, subPieceBuilder: null, ignoreWhiteSpace, ignoreCase);
-        }
-
-        private static ChangeType BuildDiffPieces(DiffResult diffResult, List<DiffPiece> oldPieces, List<DiffPiece> newPieces, PieceBuilder subPieceBuilder, bool ignoreWhiteSpace, bool ignoreCase)
-        {
-            int aPos = 0;
-            int bPos = 0;
-
-            foreach (var diffBlock in diffResult.DiffBlocks)
-            {
-                while (bPos < diffBlock.InsertStartB && aPos < diffBlock.DeleteStartA)
-                {
-                    oldPieces.Add(new DiffPiece(diffResult.PiecesOld[aPos], ChangeType.Unchanged, aPos + 1));
-                    newPieces.Add(new DiffPiece(diffResult.PiecesNew[bPos], ChangeType.Unchanged, bPos + 1));
-                    aPos++;
-                    bPos++;
-                }
-
-                int i = 0;
-                for (; i < Math.Min(diffBlock.DeleteCountA, diffBlock.InsertCountB); i++)
-                {
-                    var oldPiece = new DiffPiece(diffResult.PiecesOld[i + diffBlock.DeleteStartA], ChangeType.Deleted, aPos + 1);
-                    var newPiece = new DiffPiece(diffResult.PiecesNew[i + diffBlock.InsertStartB], ChangeType.Inserted, bPos + 1);
-
-                    if (subPieceBuilder != null)
-                    {
-                        var subChangeSummary = subPieceBuilder(diffResult.PiecesOld[aPos], diffResult.PiecesNew[bPos], oldPiece.SubPieces, newPiece.SubPieces, ignoreWhiteSpace, ignoreCase);
-                        newPiece.Type = oldPiece.Type = subChangeSummary;
-                    }
-
-                    oldPieces.Add(oldPiece);
-                    newPieces.Add(newPiece);
-                    aPos++;
-                    bPos++;
-                }
-
-                if (diffBlock.DeleteCountA > diffBlock.InsertCountB)
-                {
-                    for (; i < diffBlock.DeleteCountA; i++)
-                    {
-                        oldPieces.Add(new DiffPiece(diffResult.PiecesOld[i + diffBlock.DeleteStartA], ChangeType.Deleted, aPos + 1));
-                        newPieces.Add(new DiffPiece());
-                        aPos++;
-                    }
-                }
-                else
-                {
-                    for (; i < diffBlock.InsertCountB; i++)
-                    {
-                        newPieces.Add(new DiffPiece(diffResult.PiecesNew[i + diffBlock.InsertStartB], ChangeType.Inserted, bPos + 1));
-                        oldPieces.Add(new DiffPiece());
-                        bPos++;
-                    }
-                }
-            }
-
-            while (bPos < diffResult.PiecesNew.Count && aPos < diffResult.PiecesOld.Count)
+            while (bPos < diffBlock.InsertStartB && aPos < diffBlock.DeleteStartA)
             {
                 oldPieces.Add(new DiffPiece(diffResult.PiecesOld[aPos], ChangeType.Unchanged, aPos + 1));
                 newPieces.Add(new DiffPiece(diffResult.PiecesNew[bPos], ChangeType.Unchanged, bPos + 1));
@@ -186,18 +177,64 @@ namespace DiffPlex.DiffBuilder
                 bPos++;
             }
 
-            // Consider the whole diff as "modified" if we found any change, otherwise we consider it unchanged
-            if(oldPieces.Any(x => x.Type is ChangeType.Modified or ChangeType.Inserted or ChangeType.Deleted))
+            int i = 0;
+            for (; i < Math.Min(diffBlock.DeleteCountA, diffBlock.InsertCountB); i++)
             {
-                return ChangeType.Modified;
+                var oldPieceType = ChangeType.Deleted;
+                var newPieceType = ChangeType.Inserted;
+                var oldSubPieces = new List<DiffPiece>();
+                var newSubPieces = new List<DiffPiece>();
+                if (subPieceBuilder != null)
+                {
+                    var subChangeSummary = subPieceBuilder(diffResult.PiecesOld[aPos], diffResult.PiecesNew[bPos], oldSubPieces, newSubPieces, ignoreWhiteSpace, ignoreCase);
+                    oldPieceType = newPieceType = subChangeSummary;
+                }
+
+                oldPieces.Add(new(diffResult.PiecesOld[i + diffBlock.DeleteStartA], oldPieceType, aPos + 1, oldSubPieces));
+                newPieces.Add(new(diffResult.PiecesNew[i + diffBlock.InsertStartB], newPieceType, bPos + 1, newSubPieces));
+                aPos++;
+                bPos++;
             }
 
-            if (newPieces.Any(x => x.Type is ChangeType.Modified or ChangeType.Inserted or ChangeType.Deleted))
+            if (diffBlock.DeleteCountA > diffBlock.InsertCountB)
             {
-                return ChangeType.Modified;
+                for (; i < diffBlock.DeleteCountA; i++)
+                {
+                    oldPieces.Add(new DiffPiece(diffResult.PiecesOld[i + diffBlock.DeleteStartA], ChangeType.Deleted, aPos + 1));
+                    newPieces.Add(new DiffPiece());
+                    aPos++;
+                }
             }
-
-            return ChangeType.Unchanged;
+            else
+            {
+                for (; i < diffBlock.InsertCountB; i++)
+                {
+                    newPieces.Add(new DiffPiece(diffResult.PiecesNew[i + diffBlock.InsertStartB], ChangeType.Inserted, bPos + 1));
+                    oldPieces.Add(new DiffPiece());
+                    bPos++;
+                }
+            }
         }
+
+        while (bPos < diffResult.PiecesNew.Count && aPos < diffResult.PiecesOld.Count)
+        {
+            oldPieces.Add(new DiffPiece(diffResult.PiecesOld[aPos], ChangeType.Unchanged, aPos + 1));
+            newPieces.Add(new DiffPiece(diffResult.PiecesNew[bPos], ChangeType.Unchanged, bPos + 1));
+            aPos++;
+            bPos++;
+        }
+
+        // Consider the whole diff as "modified" if we found any change, otherwise we consider it unchanged
+        if(oldPieces.Any(x => x.Type is ChangeType.Modified or ChangeType.Inserted or ChangeType.Deleted))
+        {
+            return ChangeType.Modified;
+        }
+
+        if (newPieces.Any(x => x.Type is ChangeType.Modified or ChangeType.Inserted or ChangeType.Deleted))
+        {
+            return ChangeType.Modified;
+        }
+
+        return ChangeType.Unchanged;
     }
 }

--- a/DiffPlex/DiffPlex.csproj
+++ b/DiffPlex/DiffPlex.csproj
@@ -1,13 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NuGet.props" />
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.0;netstandard2.0;net6.0</TargetFrameworks>
-    <Version>1.7.2</Version>
+    <TargetFrameworks>net45;net462;net48;netstandard1.0;netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <Version>2.0.0</Version>
     <PackageTags>diff</PackageTags>
     <Description>DiffPlex is a diffing library that allows you to programmatically create text diffs. DiffPlex is a fast and tested library.</Description>
-    <PackageReleaseNotes>Fixed diffing of sub-components (like words). Ensures ignoreWhitespace and ignoreCase are honored in that case and that the parent reflects modification state of the child.</PackageReleaseNotes>
+    <PackageReleaseNotes>Modernization with ReadOnlySpan&lt;char&gt; and JSON supports.</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net462'">
+    <PackageReference Include="System.Memory" />
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>

--- a/DiffPlex/DiffPlex.csproj
+++ b/DiffPlex/DiffPlex.csproj
@@ -13,6 +13,6 @@
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/DiffPlex/IChunker.cs
+++ b/DiffPlex/IChunker.cs
@@ -1,15 +1,28 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
-namespace DiffPlex
+namespace DiffPlex;
+
+/// <summary>
+/// Responsible for how to turn the document into pieces
+/// </summary>
+public interface IChunker
 {
     /// <summary>
-    /// Responsible for how to turn the document into pieces
+    /// Divide text into sub-parts
     /// </summary>
-    public interface IChunker
-    {
-        /// <summary>
-        /// Divide text into sub-parts
-        /// </summary>
-        IReadOnlyList<string> Chunk(string text);
-    }
+    IReadOnlyList<string> Chunk(string text);
 }
+
+#if !NET_TOO_OLD_VER
+/// <summary>
+/// Responsible for how to turn the document into pieces
+/// </summary>
+public interface ISpanChunker : IChunker
+{
+    /// <summary>
+    /// Divide text into sub-parts
+    /// </summary>
+    IReadOnlyList<string> Chunk(ReadOnlySpan<char> text);
+}
+#endif

--- a/DiffPlex/IDiffer.cs
+++ b/DiffPlex/IDiffer.cs
@@ -42,5 +42,18 @@ namespace DiffPlex
         /// <param name="chunker">Component responsible for tokenizing the compared texts</param>
         /// <returns>A <see cref="DiffResult"/> object which details the differences</returns>
         DiffResult CreateDiffs(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase, IChunker chunker);
+
+#if !NET_TOO_OLD_VER
+        /// <summary>
+        /// Creates a diff by comparing text line by line.
+        /// </summary>
+        /// <param name="oldText">The old text.</param>
+        /// <param name="newText">The new text.</param>
+        /// <param name="ignoreWhiteSpace">If set to <see langword="true"/> will ignore white space when determining if lines are the same.</param>
+        /// <param name="ignoreCase">Determine if the text comparision is case sensitive or not</param>
+        /// <param name="chunker">Component responsible for tokenizing the compared texts</param>
+        /// <returns>A <see cref="DiffResult"/> object which details the differences</returns>
+        DiffResult CreateDiffs(ReadOnlySpan<char> oldText, ReadOnlySpan<char> newText, bool ignoreWhiteSpace, bool ignoreCase, IChunker chunker);
+#endif
     }
 }

--- a/DiffPlex/Model/DiffBlock.cs
+++ b/DiffPlex/Model/DiffBlock.cs
@@ -1,37 +1,36 @@
-﻿namespace DiffPlex.Model
+﻿namespace DiffPlex.Model;
+
+/// <summary>
+/// A block of consecutive edits from A and/or B
+/// </summary>
+public class DiffBlock
 {
     /// <summary>
-    /// A block of consecutive edits from A and/or B
+    /// Position where deletions in A begin
     /// </summary>
-    public class DiffBlock
+    public int DeleteStartA { get; }
+
+    /// <summary>
+    /// The number of deletions in A
+    /// </summary>
+    public int DeleteCountA { get; }
+
+    /// <summary>
+    /// Position where insertion in B begin
+    /// </summary>
+    public int InsertStartB { get; }
+
+    /// <summary>
+    /// The number of insertions in B
+    /// </summary>
+    public int InsertCountB { get; }
+
+
+    public DiffBlock(int deleteStartA, int deleteCountA, int insertStartB, int insertCountB)
     {
-        /// <summary>
-        /// Position where deletions in A begin
-        /// </summary>
-        public int DeleteStartA { get; }
-
-        /// <summary>
-        /// The number of deletions in A
-        /// </summary>
-        public int DeleteCountA { get; }
-
-        /// <summary>
-        /// Position where insertion in B begin
-        /// </summary>
-        public int InsertStartB { get; }
-
-        /// <summary>
-        /// The number of insertions in B
-        /// </summary>
-        public int InsertCountB { get; }
-
-
-        public DiffBlock(int deleteStartA, int deleteCountA, int insertStartB, int insertCountB)
-        {
-            DeleteStartA = deleteStartA;
-            DeleteCountA = deleteCountA;
-            InsertStartB = insertStartB;
-            InsertCountB = insertCountB;
-        }
+        DeleteStartA = deleteStartA;
+        DeleteCountA = deleteCountA;
+        InsertStartB = insertStartB;
+        InsertCountB = insertCountB;
     }
 }

--- a/DiffPlex/Model/DiffResult.cs
+++ b/DiffPlex/Model/DiffResult.cs
@@ -1,33 +1,31 @@
 ﻿using System.Collections.Generic;
 
-namespace DiffPlex.Model
+namespace DiffPlex.Model;
+
+/// <summary>
+/// The result of diffing two pieces of text
+/// </summary>
+public class DiffResult
 {
     /// <summary>
-    /// The result of diffing two pieces of text
+    /// The chunked pieces of the old text
     /// </summary>
-    public class DiffResult
+    public IReadOnlyList<string> PiecesOld { get; }
+
+    /// <summary>
+    /// The chunked pieces of the new text
+    /// </summary>
+    public IReadOnlyList<string> PiecesNew { get; }
+
+    /// <summary>
+    /// A collection of DiffBlocks which details deletions and insertions
+    /// </summary>
+    public IList<DiffBlock> DiffBlocks { get; }
+
+    public DiffResult(IReadOnlyList<string> piecesOld, IReadOnlyList<string> piecesNew, IList<DiffBlock> blocks)
     {
-        /// <summary>
-        /// The chunked pieces of the old text
-        /// </summary>
-        public IReadOnlyList<string> PiecesOld { get; }
-
-        /// <summary>
-        /// The chunked pieces of the new text
-        /// </summary>
-        public IReadOnlyList<string> PiecesNew { get; }
-
-
-        /// <summary>
-        /// A collection of DiffBlocks which details deletions and insertions
-        /// </summary>
-        public IList<DiffBlock> DiffBlocks { get; }
-
-        public DiffResult(IReadOnlyList<string> piecesOld, IReadOnlyList<string> piecesNew, IList<DiffBlock> blocks)
-        {
-            PiecesOld = piecesOld;
-            PiecesNew = piecesNew;
-            DiffBlocks = blocks;
-        }
+        PiecesOld = piecesOld;
+        PiecesNew = piecesNew;
+        DiffBlocks = blocks;
     }
 }

--- a/DiffPlex/Model/EditLengthResult.cs
+++ b/DiffPlex/Model/EditLengthResult.cs
@@ -1,23 +1,22 @@
-﻿namespace DiffPlex.Model
+﻿namespace DiffPlex.Model;
+
+public enum Edit
 {
-    public enum Edit
-    {
-        None,
-        DeleteRight,
-        DeleteLeft,
-        InsertDown,
-        InsertUp
-    }
+    None,
+    DeleteRight,
+    DeleteLeft,
+    InsertDown,
+    InsertUp
+}
 
-    public class EditLengthResult
-    {
-        public int EditLength { get; set; }
+public class EditLengthResult
+{
+    public int EditLength { get; set; }
 
-        public int StartX { get; set; }
-        public int EndX { get; set; }
-        public int StartY { get; set; }
-        public int EndY { get; set; }
+    public int StartX { get; set; }
+    public int EndX { get; set; }
+    public int StartY { get; set; }
+    public int EndY { get; set; }
 
-        public Edit LastEdit { get; set; }
-    }
+    public Edit LastEdit { get; set; }
 }

--- a/DiffPlex/Model/ModificationData.cs
+++ b/DiffPlex/Model/ModificationData.cs
@@ -1,20 +1,23 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
-namespace DiffPlex.Model
+namespace DiffPlex.Model;
+
+public class ModificationData : ModificationDataInfo
 {
-    public class ModificationData
+    public ModificationData(string str)
     {
-        public int[] HashedPieces { get; set; }
-
-        public string RawData { get; }
-
-        public bool[] Modifications { get; set; }
-
-        public IReadOnlyList<string> Pieces { get; set; }
-
-        public ModificationData(string str)
-        {
-            RawData = str;
-        }
+        RawData = str;
     }
+
+    public string RawData { get; }
+}
+
+public class ModificationDataInfo
+{
+    public int[] HashedPieces { get; set; }
+
+    public bool[] Modifications { get; set; }
+
+    public IReadOnlyList<string> Pieces { get; set; }
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,22 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.14.0" />
+    <PackageVersion Include="System.Memory" Version="4.6.0" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageVersion Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2957.106" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Trivial.WindowsKit" Version="9.3.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
+  </ItemGroup>
+</Project>

--- a/Facts.DiffPlex/DiffBuilder/JsonDiffModelFacts.cs
+++ b/Facts.DiffPlex/DiffBuilder/JsonDiffModelFacts.cs
@@ -1,0 +1,50 @@
+﻿using DiffPlex.DiffBuilder.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Facts.DiffPlex.DiffBuilder;
+
+/// <summary>
+/// The JSON supports test suite of diff models.
+/// </summary>
+public class JsonDiffModelFacts
+{
+    /// <summary>
+    /// Tests for the JSON serialization supports of diff models.
+    /// </summary>
+    [Fact]
+    public void TestSerialization()
+    {
+        var t = "The diff model is invalid but does not matter since it is only used for testing.";
+        var model = new SideBySideDiffModel(new List<DiffPiece>
+        {
+            new(),
+            new(t, ChangeType.Inserted, 20),
+            new("Another test text here…", ChangeType.Deleted, 10),
+        }, null);
+        var s = JsonSerializer.Serialize(model);
+        model = JsonSerializer.Deserialize<SideBySideDiffModel>(s);
+        Assert.NotNull(model);
+        Assert.Equal(3, model.OldText.Count);
+        Assert.Null(model.OldText.Lines[0].Text);
+        Assert.Equal(t, model.OldText.Lines[1].Text);
+        Assert.Equal(ChangeType.Inserted, model.OldText.Lines[1].Type);
+        Assert.Equal(ChangeType.Deleted, model.OldText.Lines[2].Type);
+        Assert.Equal(0, model.NewText.Count);
+        s = JsonSerializer.Serialize(model.OldText);
+        model = new(JsonSerializer.Deserialize<DiffPaneModel>(s), null);
+        Assert.Equal(3, model.OldText.Count);
+        Assert.Null(model.OldText.Lines[0].Text);
+        Assert.Equal(t, model.OldText.Lines[1].Text);
+        Assert.Equal(ChangeType.Inserted, model.OldText.Lines[1].Type);
+        Assert.Equal(ChangeType.Deleted, model.OldText.Lines[2].Type);
+        Assert.Equal(0, model.NewText.Count);
+        s = model.OldText.Join();
+        Assert.NotNull(s);
+    }
+}

--- a/Facts.DiffPlex/Facts.DiffPlex.csproj
+++ b/Facts.DiffPlex/Facts.DiffPlex.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Facts.DiffPlex/SideBySideDiffBuilderFacts.cs
+++ b/Facts.DiffPlex/SideBySideDiffBuilderFacts.cs
@@ -432,31 +432,22 @@ namespace Facts.DiffPlex
                     new DiffPiece[]
                     {
                         new DiffPiece("1", ChangeType.Unchanged, 1),
-                        new DiffPiece(" 2", ChangeType.Modified, 2)
+                        new DiffPiece(" 2", ChangeType.Modified, 2, new List<DiffPiece>
                         {
-                            SubPieces =
-                            {
-                                new DiffPiece(" ", ChangeType.Deleted, 1),
-                                new DiffPiece("2", ChangeType.Unchanged, 2),
-                            },
-                        },
-                        new DiffPiece("3 ", ChangeType.Modified, 3)
+                            new DiffPiece(" ", ChangeType.Deleted, 1),
+                            new DiffPiece("2", ChangeType.Unchanged, 2),
+                        }),
+                        new DiffPiece("3 ", ChangeType.Modified, 3, new List<DiffPiece>
                         {
-                            SubPieces =
-                            {
-                                new DiffPiece("3", ChangeType.Unchanged, 1),
-                                new DiffPiece(" ", ChangeType.Deleted, 2),
-                            },
-                        },
-                        new DiffPiece(" 4 ", ChangeType.Modified, 4)
+                            new DiffPiece("3", ChangeType.Unchanged, 1),
+                            new DiffPiece(" ", ChangeType.Deleted, 2),
+                        }),
+                        new DiffPiece(" 4 ", ChangeType.Modified, 4, new List<DiffPiece>
                         {
-                            SubPieces =
-                            {
-                                new DiffPiece(" ", ChangeType.Deleted, 1),
-                                new DiffPiece("4", ChangeType.Unchanged, 2),
-                                new DiffPiece(" ", ChangeType.Deleted, 3),
-                            },
-                        },
+                            new DiffPiece(" ", ChangeType.Deleted, 1),
+                            new DiffPiece("4", ChangeType.Unchanged, 2),
+                            new DiffPiece(" ", ChangeType.Deleted, 3),
+                        }),
                         new DiffPiece("5", ChangeType.Unchanged, 5),
                     });
                 Assert.Equal(
@@ -464,31 +455,22 @@ namespace Facts.DiffPlex
                     new DiffPiece[]
                     {
                         new DiffPiece("1", ChangeType.Unchanged, 1),
-                        new DiffPiece("2", ChangeType.Modified, 2)
+                        new DiffPiece("2", ChangeType.Modified, 2, new List<DiffPiece>
                         {
-                            SubPieces =
-                            {
-                                new DiffPiece(null, ChangeType.Imaginary),
-                                new DiffPiece("2", ChangeType.Unchanged, 1),
-                            },
-                        },
-                        new DiffPiece("3", ChangeType.Modified, 3)
+                            new DiffPiece(null, ChangeType.Imaginary),
+                            new DiffPiece("2", ChangeType.Unchanged, 1),
+                        }),
+                        new DiffPiece("3", ChangeType.Modified, 3, new List<DiffPiece>
                         {
-                            SubPieces =
-                            {
-                                new DiffPiece("3", ChangeType.Unchanged, 1),
-                                new DiffPiece(null, ChangeType.Imaginary),
-                            },
-                        },
-                        new DiffPiece("4", ChangeType.Modified, 4)
+                            new DiffPiece("3", ChangeType.Unchanged, 1),
+                            new DiffPiece(null, ChangeType.Imaginary),
+                        }),
+                        new DiffPiece("4", ChangeType.Modified, 4, new List<DiffPiece>
                         {
-                            SubPieces =
-                            {
-                                new DiffPiece(null, ChangeType.Imaginary),
-                                new DiffPiece("4", ChangeType.Unchanged, 1),
-                                new DiffPiece(null, ChangeType.Imaginary),
-                            },
-                        },
+                            new DiffPiece(null, ChangeType.Imaginary),
+                            new DiffPiece("4", ChangeType.Unchanged, 1),
+                            new DiffPiece(null, ChangeType.Imaginary),
+                        }),
                         new DiffPiece("5", ChangeType.Unchanged, 5),
                     });
             }

--- a/NuGet.props
+++ b/NuGet.props
@@ -17,7 +17,7 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.0' OR '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net30'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.0' OR '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net35'">
     <DefineConstants>NET_TOO_OLD_VER</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/NuGet.props
+++ b/NuGet.props
@@ -17,8 +17,11 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.0' OR '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net30'">
+    <DefineConstants>NET_TOO_OLD_VER</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/> 
     <None Include="$(MSBuildThisFileDirectory)\images\diffplex_icon.png" Pack="true" PackagePath="diffplex_icon.png" />
   </ItemGroup>
 </Project>

--- a/Perf.DiffPlex/Perf.DiffPlex.csproj
+++ b/Perf.DiffPlex/Perf.DiffPlex.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" />
   </ItemGroup>
 
 </Project>

--- a/WebDiffer/WebDiffer.csproj
+++ b/WebDiffer/WebDiffer.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DiffPlex\DiffPlex.csproj" />


### PR DESCRIPTION
This PR is a significant change of core library `DiffPlex`.

1. Add `ReadOnlySpan<char>` supports to differ and its accessories. At the same time, update the TFM to enable this feature on the available targets. This type is always used for some high performance scenarios to decrease unnecessary memory costs.
2. Refactor the builder models to remove the write-accessor of their properties since they are originally designed as data view of result. This breaking change ensures it comes to what to expect now. The incidental changes include updating their constructors to pass parameters instead of properties assignment.
3. Add full JSON serialization supports of builder models by implementing their bi-converters. But this also mean to add related package references like `System.Text.Json` for older TFM platforms, e.g. on .NET Frameworks. And please note this feature is disabled on .NET Strandard 1.0 because of not supported.
4. Suggest increase the major version (to v2.0) and please approach this PR with caution since the modification is wide-ranging. And of course, there is no change of the key logic and the overall mode. Additionally, the WPF components project and Windows App SDK (WinUI 3) components project are updated to adapt the new design.