### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,6 @@
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mmanela/diffplex/security/code-scanning/1](https://github.com/mmanela/diffplex/security/code-scanning/1)

To fix this problem, we should add an explicit `permissions` block to the workflow, either at the workflow root (recommended for a single-job workflow as shown) or for the specific job. Based on the workflow steps, only code checkout and .NET restore/build/test tasks are performed, none of which require write access to repository contents or other resources. Therefore, we will add `permissions: contents: read` as the minimal starting point near the top of `.github/workflows/dotnet.yml`, just below the workflow name.

- Change: Add a block after line 1 (`name: .NET`) with `permissions:\n  contents: read`.
- No changes to existing steps or imports are needed.
- No further dependencies or changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
